### PR TITLE
docs(template): add sure-aio support thread url

### DIFF
--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -7,7 +7,7 @@
   <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
-  <Support>https://github.com/JSONbored/sure-aio/issues</Support>
+  <Support>https://forums.unraid.net/topic/198074-support-sure-aio-all-in-one-sure-for-unraid/</Support>
   <Project>https://github.com/JSONbored/sure-aio</Project>
   <Overview>Sure (formerly Maybe Finance) is a self-hosted personal finance app for budgeting, net worth tracking, and account aggregation.&#xD;
 &#xD;


### PR DESCRIPTION
Update the template Support field to the live Unraid forum support thread.

This makes the synced awesome-unraid template point users to the correct CA-style support location instead of the GitHub issues URL.
