### PR TITLE
ci(release): add one-dispatch full release orchestration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
         options:
           - prepare
           - publish
+          - full
+      auto_merge_release_pr:
+        description: "For action=full, automatically merge the generated release PR"
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   prepare-release:
@@ -94,6 +100,215 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Determine release version
+        id: version
+        run: |
+          release_version="$(python3 scripts/release.py latest-changelog-version)"
+          echo "release_version=${release_version}" >> "${GITHUB_OUTPUT}"
+          release_commit="$(python3 scripts/release.py find-release-commit "${release_version}")"
+          echo "release_commit=${release_commit}" >> "${GITHUB_OUTPUT}"
+          echo "Matched release commit ${release_commit} for ${release_version}"
+          changelog_version="$(python3 scripts/release.py latest-changelog-version)"
+          if [[ "${changelog_version}" != "${release_version}" ]]; then
+            echo "CHANGELOG top entry ${changelog_version} does not match ${release_version}" >&2
+            exit 1
+          fi
+
+      - name: Extract release notes
+        id: notes
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: |
+          {
+            echo "release_notes<<EOF"
+            python3 scripts/release.py extract-release-notes "${RELEASE_VERSION}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create Git tag if missing
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          RELEASE_COMMIT: ${{ steps.version.outputs.release_commit }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          if git rev-parse "${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "Tag ${RELEASE_VERSION} already exists; skipping."
+            exit 0
+          fi
+
+          auth_token="${RELEASE_TOKEN:-${GITHUB_TOKEN}}"
+          if [[ -z "${auth_token}" ]]; then
+            echo "No token available for tag creation." >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git tag "${RELEASE_VERSION}" "${RELEASE_COMMIT}"
+          git push "https://x-access-token:${auth_token}@github.com/${GITHUB_REPOSITORY}.git" "${RELEASE_VERSION}"
+
+      - name: Publish GitHub release
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
+          RELEASE_COMMIT: ${{ steps.version.outputs.release_commit }}
+        run: |
+          export GITHUB_TOKEN="${RELEASE_TOKEN:-${GITHUB_TOKEN}}"
+
+          if gh release view "${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "GitHub release ${RELEASE_VERSION} already exists; skipping."
+            exit 0
+          fi
+
+          notes_file="$(mktemp)"
+          printf '%s\n' "${RELEASE_NOTES}" > "${notes_file}"
+          gh release create "${RELEASE_VERSION}" \
+            --title "${RELEASE_VERSION}" \
+            --notes-file "${notes_file}" \
+            --target "${RELEASE_COMMIT}"
+
+      - name: Trigger image publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "CI / Sure-AIO" \
+            --ref main \
+            -f publish_image=true \
+            -f run_smoke_test=false
+          echo "Triggered CI / Sure-AIO workflow_dispatch with publish_image=true."
+
+  full-release:
+    if: ${{ github.event.inputs.action == 'full' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    env:
+      AUTO_MERGE: ${{ github.event.inputs.auto_merge_release_pr }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install git-cliff
+        env:
+          GIT_CLIFF_VERSION: 2.12.0
+        run: |
+          archive="git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL -o "/tmp/${archive}" "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${archive}"
+          tar -xzf "/tmp/${archive}" -C /tmp
+          install "/tmp/git-cliff-${GIT_CLIFF_VERSION}/git-cliff" /usr/local/bin/git-cliff
+          git-cliff --version
+
+      - name: Check for unreleased changes
+        id: changes
+        run: |
+          echo "has_changes=$(python3 scripts/release.py has-unreleased-changes)" >> "${GITHUB_OUTPUT}"
+
+      - name: Compute release version
+        id: prepare_version
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          release_version="$(python3 scripts/release.py next-version)"
+          echo "release_version=${release_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate changelog
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.prepare_version.outputs.release_version }}
+        run: |
+          previous_tag="$(python3 scripts/release.py latest-aio-tag)"
+          if [[ -n "${previous_tag}" ]]; then
+            git-cliff --config cliff.toml --tag "${RELEASE_VERSION}" "${previous_tag}..HEAD" --output CHANGELOG.md
+          else
+            git-cliff --config cliff.toml --tag "${RELEASE_VERSION}" --output CHANGELOG.md
+          fi
+          parsed_version="$(python3 scripts/release.py latest-changelog-version)"
+          if [[ "${parsed_version}" != "${RELEASE_VERSION}" ]]; then
+            echo "Generated changelog top section ${parsed_version} does not match ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+      - name: Create release PR
+        if: steps.changes.outputs.has_changes == 'true'
+        id: release_pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: "chore(release): ${{ steps.prepare_version.outputs.release_version }}"
+          title: "chore(release): ${{ steps.prepare_version.outputs.release_version }}"
+          body: |
+            This PR prepares `${{ steps.prepare_version.outputs.release_version }}`.
+
+            - updates `CHANGELOG.md` with `git-cliff`
+            - is intended to be merged to `main`
+            - was created by `action=full` release orchestration
+          branch: "release/${{ steps.prepare_version.outputs.release_version }}"
+          delete-branch: true
+
+      - name: Require auto-merge for full mode
+        if: steps.changes.outputs.has_changes == 'true' && env.AUTO_MERGE != 'true'
+        run: |
+          echo "full mode requires auto_merge_release_pr=true to complete in one dispatch." >&2
+          exit 1
+
+      - name: Enable release PR auto-merge
+        if: steps.changes.outputs.has_changes == 'true' && env.AUTO_MERGE == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.release_pr.outputs.pull-request-number }}
+        run: |
+          auth_token="${RELEASE_TOKEN:-${GITHUB_TOKEN}}"
+          if [[ -z "${auth_token}" ]]; then
+            echo "No token available for PR auto-merge." >&2
+            exit 1
+          fi
+          export GH_TOKEN="${auth_token}"
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch --auto
+          echo "Auto-merge enabled for release PR #${PR_NUMBER}."
+
+      - name: Wait for release PR merge
+        if: steps.changes.outputs.has_changes == 'true' && env.AUTO_MERGE == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.release_pr.outputs.pull-request-number }}
+        run: |
+          auth_token="${RELEASE_TOKEN:-${GITHUB_TOKEN}}"
+          if [[ -z "${auth_token}" ]]; then
+            echo "No token available for PR merge polling." >&2
+            exit 1
+          fi
+          export GH_TOKEN="${auth_token}"
+          deadline=$((SECONDS + 1800))
+          while (( SECONDS < deadline )); do
+            merged_at="$(gh pr view "${PR_NUMBER}" --json mergedAt --jq '.mergedAt')"
+            if [[ "${merged_at}" != "null" && -n "${merged_at}" ]]; then
+              echo "Release PR #${PR_NUMBER} merged at ${merged_at}."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for release PR #${PR_NUMBER} to merge." >&2
+          exit 1
+
+      - name: Refresh checkout after release merge
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
 
       - name: Determine release version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
     if: ${{ github.event.inputs.action == 'publish' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Checkout main
@@ -165,3 +166,13 @@ jobs:
             --title "${RELEASE_VERSION}" \
             --notes-file "${notes_file}" \
             --target "${RELEASE_COMMIT}"
+
+      - name: Trigger image publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "CI / Sure-AIO" \
+            --ref main \
+            -f publish_image=true \
+            -f run_smoke_test=false
+          echo "Triggered CI / Sure-AIO workflow_dispatch with publish_image=true."

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -27,3 +27,18 @@ Every `main` build publishes:
 4. Trigger **Release / Sure-AIO** from `main` again with `action=publish`.
 5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag, and publishes the GitHub Release.
 6. The same publish job automatically dispatches **CI / Sure-AIO** (`workflow_dispatch`) with `publish_image=true` so GHCR package tags (including `upstream-aio-vN`) stay aligned with the new release revision.
+
+## One-dispatch mode
+
+You can run the same workflow with `action=full` for one-dispatch orchestration:
+
+1. Creates/updates the release PR from `CHANGELOG.md` generation.
+2. Enables auto-merge on that PR.
+3. Waits for merge to complete.
+4. Creates the Git tag and publishes the GitHub Release.
+5. Dispatches **CI / Sure-AIO** with `publish_image=true` to publish GHCR tags.
+
+Notes:
+
+- `action=full` requires `auto_merge_release_pr=true` (default).
+- If branch protection/policy blocks auto-merge, the workflow fails with a clear message and no partial hidden state.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -26,3 +26,4 @@ Every `main` build publishes:
 3. Review and merge that PR into `main`.
 4. Trigger **Release / Sure-AIO** from `main` again with `action=publish`.
 5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag, and publishes the GitHub Release.
+6. The same publish job automatically dispatches **CI / Sure-AIO** (`workflow_dispatch`) with `publish_image=true` so GHCR package tags (including `upstream-aio-vN`) stay aligned with the new release revision.


### PR DESCRIPTION
## Summary
This PR adds a single-dispatch release path so `sure-aio` can run release preparation, merge, release publish, and image publish orchestration in one workflow execution.

## What changed
- Added `action=full` to `Release / Sure-AIO` workflow dispatch options.
- Added `auto_merge_release_pr` input (default `true`) for full-mode automation control.
- Added new `full-release` job that:
  - computes next release version and generates changelog
  - creates/updates release PR
  - enables auto-merge and waits for merge completion
  - refreshes `main`, creates Git tag, publishes GitHub release
  - dispatches `CI / Sure-AIO` with `publish_image=true` to publish GHCR package tags
- Added `actions: write` permission where needed for workflow dispatch and automation steps.
- Updated release docs to describe one-dispatch mode and failure behavior when auto-merge is blocked by policy.

## Why
- Remove repetitive, error-prone manual release sequencing (`prepare` -> merge -> `publish` -> manual image publish trigger).
- Ensure release revision and GHCR `upstream-aio-vN` package tags remain aligned automatically.
- Improve maintainability and operator ergonomics for ongoing release management.

## Validation
- Parsed workflow YAML successfully (`release.yml ok`).
- Verified presence of new inputs, `full-release` orchestration steps, and auto-publish dispatch wiring.
- Updated documentation references for the new release mode.

## Notes
- Recommended trigger moving forward: `Release / Sure-AIO` with `action=full` on `main`.
- If branch protection blocks bot auto-merge, `action=full` will fail clearly; fallback remains `prepare` + manual merge + `publish`.
