### PR TITLE
fix(template): restore CA trust signals and automate changelog sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,7 @@ jobs:
           bash -n scripts/smoke-test.sh
           PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/check-upstream.py
           PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/validate-template.py
+          PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/update-template-changes.py
           find rootfs -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
           find rootfs -type f -path '*/run' -print0 | xargs -0 -n1 bash -n
           find rootfs -type f -path '*/up' -print0 | xargs -0 -n1 sh -n

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,9 +308,11 @@ jobs:
         env:
           AIO_TRACK_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.aio_track_override || '' }}
           DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+          DOCKERHUB_IMAGE_NAME: ${{ secrets.DOCKERHUB_IMAGE_NAME }}
         run: |
           image_ghcr="$(printf '%s' "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
-          image_dockerhub="$(printf '%s' "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          dockerhub_image_name="${DOCKERHUB_IMAGE_NAME:-${IMAGE_NAME}}"
+          image_dockerhub="$(printf '%s' "${dockerhub_image_name}" | tr '[:upper:]' '[:lower:]')"
           sha_tag_ghcr="${image_ghcr}:sha-${GITHUB_SHA}"
           raw_version="$(sed -n 's/^ARG UPSTREAM_VERSION=//p' Dockerfile | head -n1)"
           upstream_version="${raw_version%%@*}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,13 +294,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Compute image tags
         id: prep
         env:
           AIO_TRACK_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.aio_track_override || '' }}
+          DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         run: |
-          image="$(printf '%s' "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
-          sha_tag="${image}:sha-${GITHUB_SHA}"
+          image_ghcr="$(printf '%s' "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          image_dockerhub="$(printf '%s' "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          sha_tag_ghcr="${image_ghcr}:sha-${GITHUB_SHA}"
           raw_version="$(sed -n 's/^ARG UPSTREAM_VERSION=//p' Dockerfile | head -n1)"
           upstream_version="${raw_version%%@*}"
           upstream_digest="$(sed -n 's/^ARG UPSTREAM_IMAGE_DIGEST=//p' Dockerfile | head -n1)"
@@ -329,12 +339,21 @@ jobs:
             echo "upstream_digest=${upstream_digest}"
             echo "aio_track=${aio_track}"
             echo "tags<<EOF"
-            echo "${image}:latest"
+            echo "${image_ghcr}:latest"
             if [[ -n "${upstream_version}" ]]; then
-              echo "${image}:${upstream_version}"
-              echo "${image}:${upstream_version}-${aio_track}"
+              echo "${image_ghcr}:${upstream_version}"
+              echo "${image_ghcr}:${upstream_version}-${aio_track}"
             fi
-            echo "${sha_tag}"
+            echo "${sha_tag_ghcr}"
+
+            if [[ "${DOCKERHUB_ENABLED}" == "true" ]]; then
+              echo "${image_dockerhub}:latest"
+              if [[ -n "${upstream_version}" ]]; then
+                echo "${image_dockerhub}:${upstream_version}"
+                echo "${image_dockerhub}:${upstream_version}-${aio_track}"
+              fi
+              echo "${image_dockerhub}:sha-${GITHUB_SHA}"
+            fi
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
@@ -358,7 +377,7 @@ jobs:
             io.jsonbored.upstream.digest=${{ steps.prep.outputs.upstream_digest || '' }}
             io.jsonbored.wrapper.name=sure-aio
             io.jsonbored.wrapper.type=unraid-aio
-            io.jsonbored.wrapper.track=aio-v1
+            io.jsonbored.wrapper.track=${{ steps.prep.outputs.aio_track }}
           load: false
 
   sync-awesome-unraid:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,13 @@ jobs:
             exit 1
           fi
 
+      - name: Sync template Changes from changelog
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: |
+          python3 scripts/update-template-changes.py "${RELEASE_VERSION}"
+
       - name: Create release PR
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -83,6 +90,7 @@ jobs:
             This PR prepares `${{ steps.version.outputs.release_version }}`.
 
             - updates `CHANGELOG.md` with `git-cliff`
+            - syncs `sure-aio.xml` `<Changes>` from `CHANGELOG.md`
             - is intended to be merged to `main`
             - requires a separate manual `publish` run after merge
           branch: "release/${{ steps.version.outputs.release_version }}"
@@ -248,6 +256,13 @@ jobs:
             exit 1
           fi
 
+      - name: Sync template Changes from changelog
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.prepare_version.outputs.release_version }}
+        run: |
+          python3 scripts/update-template-changes.py "${RELEASE_VERSION}"
+
       - name: Create release PR
         if: steps.changes.outputs.has_changes == 'true'
         id: release_pr
@@ -259,6 +274,7 @@ jobs:
             This PR prepares `${{ steps.prepare_version.outputs.release_version }}`.
 
             - updates `CHANGELOG.md` with `git-cliff`
+            - syncs `sure-aio.xml` `<Changes>` from `CHANGELOG.md`
             - is intended to be merged to `main`
             - was created by `action=full` release orchestration
           branch: "release/${{ steps.prepare_version.outputs.release_version }}"

--- a/scripts/update-template-changes.py
+++ b/scripts/update-template-changes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_CHANGELOG = ROOT / "CHANGELOG.md"
+DEFAULT_TEMPLATE = ROOT / "sure-aio.xml"
+RELEASES_URL = "https://github.com/JSONbored/sure-aio/releases"
+
+
+def extract_release_notes(version: str, changelog: pathlib.Path) -> str:
+    heading = re.compile(rf"^##\s+{re.escape(version)}(?:\s+-\s+.+)?$")
+    next_heading = re.compile(r"^##\s+")
+
+    lines = changelog.read_text().splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if heading.match(line.strip()):
+            start = idx + 1
+            break
+
+    if start is None:
+        raise SystemExit(f"Unable to find release section for {version} in {changelog}")
+
+    end = len(lines)
+    for idx in range(start, len(lines)):
+        if next_heading.match(lines[idx].strip()):
+            end = idx
+            break
+
+    notes = "\n".join(lines[start:end]).strip()
+    if not notes:
+        raise SystemExit(f"Release section for {version} in {changelog} is empty")
+    return notes
+
+
+def build_changes_body(version: str, notes: str) -> str:
+    lines: list[str] = ["[b]Latest release[/b]", f"- {version}"]
+    for line in notes.splitlines():
+        stripped = line.rstrip()
+        if not stripped:
+            lines.append("")
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        if stripped.startswith("### "):
+            lines.append(f"[b]{stripped[4:]}[/b]")
+            continue
+        lines.append(stripped)
+
+    lines.append("")
+    lines.append(
+        f"Full changelog and release notes: [url={RELEASES_URL}]GitHub Releases[/url]"
+    )
+    return "\n".join(lines).strip()
+
+
+def encode_for_template(body: str) -> str:
+    escaped = html.escape(body, quote=False)
+    return escaped.replace("\n", "&#xD;\n")
+
+
+def update_template(template_path: pathlib.Path, encoded_changes: str) -> None:
+    content = template_path.read_text()
+    pattern = re.compile(r"<Changes>.*?</Changes>", re.DOTALL)
+    replacement = f"<Changes>{encoded_changes}</Changes>"
+    updated, count = pattern.subn(replacement, content, count=1)
+    if count != 1:
+        raise SystemExit(f"Expected exactly one <Changes> block in {template_path}")
+    template_path.write_text(updated)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update sure-aio.xml <Changes> from CHANGELOG release notes."
+    )
+    parser.add_argument("version", help="Release version (example: v0.6.9-aio.4)")
+    parser.add_argument("--changelog", type=pathlib.Path, default=DEFAULT_CHANGELOG)
+    parser.add_argument("--template", type=pathlib.Path, default=DEFAULT_TEMPLATE)
+    args = parser.parse_args()
+
+    notes = extract_release_notes(args.version, args.changelog)
+    body = build_changes_body(args.version, notes)
+    update_template(args.template, encode_for_template(body))
+    print(f"Updated <Changes> in {args.template} from {args.changelog} for {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-template.py
+++ b/scripts/validate-template.py
@@ -165,6 +165,12 @@ REQUIRED_TARGETS = {
     "YAHOO_FINANCE_URL",
 }
 
+REQUIRED_CHANGELOG_LINK = "https://github.com/JSONbored/sure-aio/releases"
+ALLOWED_CATEGORY_TOKENS = {
+    "Productivity",
+    "Tools-Utilities",
+}
+
 
 def main() -> int:
     tree = ET.parse(TEMPLATE_PATH)
@@ -181,6 +187,34 @@ def main() -> int:
         print("sure-aio.xml is missing required upstream/runtime targets:", file=sys.stderr)
         for target in missing:
             print(f"  - {target}", file=sys.stderr)
+        return 1
+
+    category = (root.findtext("Category") or "").strip()
+    if not category:
+        print("sure-aio.xml is missing a <Category> value", file=sys.stderr)
+        return 1
+
+    category_tokens = [token for token in category.split(" ") if token]
+    unknown_categories = sorted(set(category_tokens) - ALLOWED_CATEGORY_TOKENS)
+    if unknown_categories:
+        print("sure-aio.xml contains unknown/unapproved category tokens:", file=sys.stderr)
+        for token in unknown_categories:
+            print(f"  - {token}", file=sys.stderr)
+        print(
+            f"Allowed tokens: {', '.join(sorted(ALLOWED_CATEGORY_TOKENS))}",
+            file=sys.stderr,
+        )
+        return 1
+
+    changes = (root.findtext("Changes") or "").strip()
+    if not changes:
+        print("sure-aio.xml is missing a non-empty <Changes> section", file=sys.stderr)
+        return 1
+    if REQUIRED_CHANGELOG_LINK not in changes:
+        print(
+            "sure-aio.xml <Changes> does not include the canonical GitHub releases URL",
+            file=sys.stderr,
+        )
         return 1
 
     print(f"sure-aio.xml parsed successfully and includes {len(REQUIRED_TARGETS)} required targets")

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -21,7 +21,13 @@ sure-aio packages the web app, worker, PostgreSQL, and Redis into one Unraid tem
 &#xD;
 [b]Advanced note[/b]&#xD;
 External database, Redis, proxy, SMTP, AI, and storage overrides are available in Advanced View.</Overview>
-  <Category>Tools: Utilities: Productivity:</Category>
+  <Changes>[b]Latest updates[/b]&#xD;
+- v0.6.9-aio.3: release/publish workflow hardening and deterministic aio image-track tagging.&#xD;
+- v0.6.9-aio.2: finalized CA metadata and expanded upstream env-surface coverage in the template.&#xD;
+- v0.6.9-aio.1: Sure 0.6.9 AIO baseline refresh.&#xD;
+&#xD;
+Full changelog and release notes: [url=https://github.com/JSONbored/sure-aio/releases]GitHub Releases[/url]</Changes>
+  <Category>Productivity Tools-Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/sure.png</Icon>

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,10 +31,11 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>[b]Latest updates[/b]&#xD;
-- v0.6.9-aio.3: release/publish workflow hardening and deterministic aio image-track tagging.&#xD;
-- v0.6.9-aio.2: finalized CA metadata and expanded upstream env-surface coverage in the template.&#xD;
-- v0.6.9-aio.1: Sure 0.6.9 AIO baseline refresh.&#xD;
+  <Changes>[b]Latest release[/b]&#xD;
+- v0.6.9-aio.3&#xD;
+[b]Fixes[/b]&#xD;
+- Stabilize upstream pinning and align AIO package tags (#41)&#xD;
+&#xD;
 &#xD;
 Full changelog and release notes: [url=https://github.com/JSONbored/sure-aio/releases]GitHub Releases[/url]</Changes>
   <Category>Productivity Tools-Utilities</Category>

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -12,15 +12,25 @@
   <Overview>Sure (formerly Maybe Finance) is a self-hosted personal finance app for budgeting, net worth tracking, and account aggregation.&#xD;
 &#xD;
 [b]All-In-One Unraid Edition[/b]&#xD;
-sure-aio packages the web app, worker, PostgreSQL, and Redis into one Unraid template with persistent appdata paths and no external database setup required.&#xD;
+`sure-aio` packages the web app, worker, PostgreSQL, and Redis into one Unraid template with persistent appdata paths, so beginners can run Sure without deploying separate DB/cache containers.&#xD;
 &#xD;
-[b]First install[/b]&#xD;
-1. Generate a [code]SECRET_KEY_BASE[/code] with [code]openssl rand -hex 64[/code].&#xD;
-2. Paste it below and click Apply.&#xD;
-3. Wait for first boot to finish provisioning the internal services.&#xD;
+[b]Quick Install (Beginners)[/b]&#xD;
+1. In Unraid, click Install for this template.&#xD;
+2. Open an Unraid terminal and generate your secret: [code]openssl rand -hex 64[/code]&#xD;
+3. Copy that value into [code]Secret Key Base[/code] ([code]SECRET_KEY_BASE[/code]) in the template form.&#xD;
+4. Leave defaults in place for first boot, then click Apply.&#xD;
+5. Wait for initialization to complete, then open [code]http://SERVER_IP:3000[/code] (or your mapped port).&#xD;
 &#xD;
-[b]Advanced note[/b]&#xD;
-External database, Redis, proxy, SMTP, AI, and storage overrides are available in Advanced View.</Overview>
+[b]Power Users (Advanced View)[/b]&#xD;
+- Enable [code]Advanced View[/code] in the template to expose full runtime/env controls.&#xD;
+- Override DB/Redis to external services if desired, or keep the AIO defaults.&#xD;
+- Configure SMTP, reverse-proxy SSL behavior, OIDC/SSO, telemetry/APM, and API/provider keys (Plaid, Yahoo, Brandfetch, AI, etc.).&#xD;
+- Keep defaults for easiest operation; only set overrides you actually need.&#xD;
+&#xD;
+[b]Data paths (default)[/b]&#xD;
+- [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
+- [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
+- [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
   <Changes>[b]Latest updates[/b]&#xD;
 - v0.6.9-aio.3: release/publish workflow hardening and deterministic aio image-track tagging.&#xD;
 - v0.6.9-aio.2: finalized CA metadata and expanded upstream env-surface coverage in the template.&#xD;


### PR DESCRIPTION
## Summary
Fixes the CA trust-signal gaps for `sure-aio` by correcting template metadata, improving Unraid-facing install guidance, and automating template changelog updates from the canonical project changelog.

## What changed
- fix CA category tokens in `sure-aio.xml` to valid values (`Productivity Tools-Utilities`)
- add and maintain a proper `<Changes>` block in `sure-aio.xml`
- improve template `Overview` content for Unraid UX:
  - clearer beginner quick-start flow
  - explicit `SECRET_KEY_BASE` generation instructions
  - concise power-user guidance
- add `scripts/update-template-changes.py` to sync XML `<Changes>` from latest `CHANGELOG.md` release section
- wire release automation to run changelog->template sync during:
  - `Release / Sure-AIO` `action=prepare`
  - `Release / Sure-AIO` `action=full`
- extend CI validation to compile-check the new sync script
- add optional Docker Hub publish path in CI (when `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` are configured) so CA can resolve `Last Update` metadata more reliably

## Why
- CA was showing weak trust signals for `sure-aio`:
  - `Last Update: Unknown`
  - missing/insufficient changelog presentation
  - prior category formatting issues
- template changelog content was previously manual and drift-prone
- release flow needed deterministic, repeatable propagation of changelog metadata into the Unraid template

## Validation
- `python3 scripts/validate-template.py`
- `PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/release.py scripts/validate-template.py scripts/check-upstream.py scripts/update-template-changes.py`
- local run of:
  - `python3 scripts/update-template-changes.py "$(python3 scripts/release.py latest-changelog-version)"`

## Notes
- `Last Update` in CA depends on CA registry metadata behavior and feed refresh timing; this PR adds the required workflow support but display timing remains CA-refresh dependent.
- Ensure Docker Hub repo/secrets are configured to activate dual-publish behavior.
