### PR TITLE
fix(ci): gate Docker Hub login without direct secrets expressions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,8 +295,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve Docker Hub publish settings
+        id: dockerhub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_IMAGE_NAME: ${{ secrets.DOCKERHUB_IMAGE_NAME }}
+        run: |
+          if [[ -n "${DOCKERHUB_USERNAME}" && -n "${DOCKERHUB_TOKEN}" ]]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+          if [[ -n "${DOCKERHUB_IMAGE_NAME}" ]]; then
+            echo "image_name=${DOCKERHUB_IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "image_name=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        if: ${{ steps.dockerhub.outputs.enabled == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
@@ -307,8 +326,8 @@ jobs:
         id: prep
         env:
           AIO_TRACK_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.aio_track_override || '' }}
-          DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
-          DOCKERHUB_IMAGE_NAME: ${{ secrets.DOCKERHUB_IMAGE_NAME }}
+          DOCKERHUB_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
+          DOCKERHUB_IMAGE_NAME: ${{ steps.dockerhub.outputs.image_name }}
         run: |
           image_ghcr="$(printf '%s' "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
           dockerhub_image_name="${DOCKERHUB_IMAGE_NAME:-${IMAGE_NAME}}"


### PR DESCRIPTION
## Summary
Fixes GitHub Actions startup failures caused by invalid direct `secrets.*` expressions in workflow conditions and restores Docker Hub publish gating.

## What changed
- add a `Resolve Docker Hub publish settings` step in `CI / Sure-AIO` publish job
- compute and expose safe step outputs:
  - `enabled` (true/false based on Docker Hub secret presence)
  - `image_name` (from `DOCKERHUB_IMAGE_NAME`, fallback to `IMAGE_NAME`)
- replace invalid condition:
  - from direct `if: ${{ secrets... }}` usage
  - to `if: ${{ steps.dockerhub.outputs.enabled == 'true' }}`
- update tag-computation env wiring to consume resolver outputs instead of direct secret expressions

## Why
- merged `main` workflows failed to parse with:
  - `Unrecognized named-value: 'secrets'`
- publish pipeline could not start until workflow syntax was corrected
- resolver-based outputs keep Docker Hub behavior optional while remaining valid for workflow parsing

## Validation
- workflow file parses correctly after update
- local template validation still passes:
  - `python3 scripts/validate-template.py`

## Notes
- Docker Hub publish remains conditional and only runs when both `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured.
- `DOCKERHUB_IMAGE_NAME` remains supported for namespace override (defaults to `jsonbored/sure-aio` via `IMAGE_NAME` fallback).

