### PR TITLE
fix(ci): make workflow-dispatch publish gates deterministic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
       xml_related: ${{ steps.filter.outputs.xml_related }}
       renovate_related: ${{ steps.filter.outputs.renovate_related }}
       tooling_related: ${{ steps.filter.outputs.tooling_related }}
+      run_smoke_requested: ${{ steps.filter.outputs.run_smoke_requested }}
+      publish_requested: ${{ steps.filter.outputs.publish_requested }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,7 +74,16 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GITHUB_SHA_VALUE: ${{ github.sha }}
+          GITHUB_REF_VALUE: ${{ github.ref }}
+          RUN_SMOKE_TEST_INPUT: ${{ github.event.inputs.run_smoke_test || '' }}
+          PUBLISH_IMAGE_INPUT: ${{ github.event.inputs.publish_image || '' }}
         run: |
+          python3 scripts/ci_flags.py \
+            --event-name "${EVENT_NAME}" \
+            --ref "${GITHUB_REF_VALUE}" \
+            --run-smoke-test-input "${RUN_SMOKE_TEST_INPUT}" \
+            --publish-image-input "${PUBLISH_IMAGE_INPUT}" >> "${GITHUB_OUTPUT}"
+
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "build_related=true" >> "${GITHUB_OUTPUT}"
             echo "xml_related=true" >> "${GITHUB_OUTPUT}"
@@ -162,12 +173,19 @@ jobs:
         if: ${{ needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.tooling_related == 'true' }}
         run: |
           bash -n scripts/smoke-test.sh
+          PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/ci_flags.py
           PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/check-upstream.py
+          PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/test-ci-flags.py
           PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/validate-template.py
           PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/update-template-changes.py
           find rootfs -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n
           find rootfs -type f -path '*/run' -print0 | xargs -0 -n1 bash -n
           find rootfs -type f -path '*/up' -print0 | xargs -0 -n1 sh -n
+
+      - name: Validate CI flag resolver behavior
+        if: ${{ needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.tooling_related == 'true' }}
+        run: |
+          python3 scripts/test-ci-flags.py
 
       - name: Validate XML
         if: ${{ needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.xml_related == 'true' }}
@@ -226,7 +244,7 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
 
   smoke-test:
-    if: ${{ needs.detect-changes.outputs.build_related == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (inputs.run_smoke_test == true || inputs.run_smoke_test == 'true'))) }}
+    if: ${{ needs.detect-changes.outputs.build_related == 'true' && needs.detect-changes.outputs.run_smoke_requested == 'true' }}
     needs:
       - detect-changes
       - validate-template
@@ -269,7 +287,7 @@ jobs:
           docker logs sure-aio-smoke || true
 
   publish:
-    if: ${{ needs.detect-changes.outputs.build_related == 'true' && github.event_name != 'pull_request' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (inputs.publish_image == true || inputs.publish_image == 'true'))) }}
+    if: ${{ needs.detect-changes.outputs.build_related == 'true' && github.event_name != 'pull_request' && needs.detect-changes.outputs.publish_requested == 'true' }}
     needs:
       - detect-changes
       - validate-template

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
 
   smoke-test:
-    if: ${{ needs.detect-changes.outputs.build_related == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_smoke_test == true)) }}
+    if: ${{ needs.detect-changes.outputs.build_related == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (inputs.run_smoke_test == true || inputs.run_smoke_test == 'true'))) }}
     needs:
       - detect-changes
       - validate-template
@@ -269,7 +269,7 @@ jobs:
           docker logs sure-aio-smoke || true
 
   publish:
-    if: ${{ needs.detect-changes.outputs.build_related == 'true' && github.event_name != 'pull_request' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.publish_image == true)) }}
+    if: ${{ needs.detect-changes.outputs.build_related == 'true' && github.event_name != 'pull_request' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (inputs.publish_image == true || inputs.publish_image == 'true'))) }}
     needs:
       - detect-changes
       - validate-template

--- a/scripts/ci_flags.py
+++ b/scripts/ci_flags.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def parse_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in TRUE_VALUES
+
+
+@dataclass(frozen=True)
+class CiFlags:
+    run_smoke_requested: bool
+    publish_requested: bool
+
+
+def resolve_flags(
+    event_name: str,
+    ref: str,
+    run_smoke_test_input: str | None = None,
+    publish_image_input: str | None = None,
+) -> CiFlags:
+    if event_name == "push" and ref == "refs/heads/main":
+        return CiFlags(run_smoke_requested=True, publish_requested=True)
+
+    if event_name == "workflow_dispatch":
+        return CiFlags(
+            run_smoke_requested=parse_bool(run_smoke_test_input),
+            publish_requested=parse_bool(publish_image_input),
+        )
+
+    return CiFlags(run_smoke_requested=False, publish_requested=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Resolve CI gate flags for build workflow.")
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--run-smoke-test-input", default="")
+    parser.add_argument("--publish-image-input", default="")
+    args = parser.parse_args()
+
+    flags = resolve_flags(
+        event_name=args.event_name,
+        ref=args.ref,
+        run_smoke_test_input=args.run_smoke_test_input,
+        publish_image_input=args.publish_image_input,
+    )
+    print(f"run_smoke_requested={'true' if flags.run_smoke_requested else 'false'}")
+    print(f"publish_requested={'true' if flags.publish_requested else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-ci-flags.py
+++ b/scripts/test-ci-flags.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from ci_flags import resolve_flags
+
+
+def main() -> int:
+    cases = [
+        # push on main always enables smoke + publish for build-related changes
+        ("push", "refs/heads/main", "", "", True, True),
+        # push on non-main should not force smoke/publish
+        ("push", "refs/heads/feature", "", "", False, False),
+        # workflow_dispatch should respect both boolean and string forms
+        ("workflow_dispatch", "refs/heads/main", "true", "true", True, True),
+        ("workflow_dispatch", "refs/heads/main", "1", "1", True, True),
+        ("workflow_dispatch", "refs/heads/main", "false", "true", False, True),
+        ("workflow_dispatch", "refs/heads/main", "", "true", False, True),
+        ("workflow_dispatch", "refs/heads/main", "true", "", True, False),
+        # PR events should never force smoke/publish from this resolver
+        ("pull_request", "refs/pull/1/merge", "", "", False, False),
+    ]
+
+    for idx, case in enumerate(cases, start=1):
+        event_name, ref, smoke_input, publish_input, expected_smoke, expected_publish = case
+        result = resolve_flags(
+            event_name=event_name,
+            ref=ref,
+            run_smoke_test_input=smoke_input,
+            publish_image_input=publish_input,
+        )
+        assert result.run_smoke_requested == expected_smoke, (
+            f"case #{idx} expected run_smoke_requested={expected_smoke}, "
+            f"got {result.run_smoke_requested}"
+        )
+        assert result.publish_requested == expected_publish, (
+            f"case #{idx} expected publish_requested={expected_publish}, "
+            f"got {result.publish_requested}"
+        )
+
+    print(f"ci_flags tests passed ({len(cases)} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Stabilizes CI gate evaluation so manual workflow dispatch inputs reliably trigger smoke/publish behavior and prevents future regressions by testing gate logic directly.

## What changed
- add `scripts/ci_flags.py` to centralize CI gate resolution for:
  - `run_smoke_requested`
  - `publish_requested`
- add `scripts/test-ci-flags.py` with explicit cases for:
  - push on main
  - push on non-main
  - workflow_dispatch true/false and string/boolean forms
  - pull_request behavior
- update `detect-changes` job in `.github/workflows/build.yml` to emit gate outputs from `ci_flags.py`
- update `smoke-test` and `publish` job `if` conditions to consume deterministic outputs from `detect-changes`
- extend validation step to compile-check new scripts and execute CI flag tests

## Why
- workflow_dispatch runs were reporting success while `publish` was skipped unexpectedly
- boolean input handling can vary (`true` vs `"true"`), causing flaky gate behavior
- gate logic needed to be testable before merge instead of discovered post-merge

## Validation
- `python3 scripts/test-ci-flags.py`
- `python3 scripts/ci_flags.py --event-name workflow_dispatch --ref refs/heads/main --run-smoke-test-input true --publish-image-input true`
- `python3 scripts/ci_flags.py --event-name workflow_dispatch --ref refs/heads/main --run-smoke-test-input false --publish-image-input false`
- `python3 scripts/validate-template.py`

## Notes
- This PR does not change release versioning; it only hardens CI execution logic.
- After merge, manual `CI / Sure-AIO` runs with `publish_image=true` should execute `publish` deterministically.
