### PR TITLE
fix(ci): always publish on manual main workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,6 @@ on:
         required: false
         default: false
         type: boolean
-      publish_image:
-        description: "Publish image tags from the current ref"
-        required: false
-        default: false
-        type: boolean
       aio_track_override:
         description: "Optional package line override (example: aio-v3)"
         required: false
@@ -76,13 +71,11 @@ jobs:
           GITHUB_SHA_VALUE: ${{ github.sha }}
           GITHUB_REF_VALUE: ${{ github.ref }}
           RUN_SMOKE_TEST_INPUT: ${{ github.event.inputs.run_smoke_test || '' }}
-          PUBLISH_IMAGE_INPUT: ${{ github.event.inputs.publish_image || '' }}
         run: |
           python3 scripts/ci_flags.py \
             --event-name "${EVENT_NAME}" \
             --ref "${GITHUB_REF_VALUE}" \
-            --run-smoke-test-input "${RUN_SMOKE_TEST_INPUT}" \
-            --publish-image-input "${PUBLISH_IMAGE_INPUT}" >> "${GITHUB_OUTPUT}"
+            --run-smoke-test-input "${RUN_SMOKE_TEST_INPUT}" >> "${GITHUB_OUTPUT}"
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "build_related=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,9 @@ jobs:
           aio_track="aio-v${release_revision}"
           gh workflow run "CI / Sure-AIO" \
             --ref main \
-            -f publish_image=true \
             -f run_smoke_test=false \
             -f aio_track_override="${aio_track}"
-          echo "Triggered CI / Sure-AIO workflow_dispatch with publish_image=true and aio_track_override=${aio_track}."
+          echo "Triggered CI / Sure-AIO workflow_dispatch on main with aio_track_override=${aio_track}."
 
   full-release:
     if: ${{ github.event.inputs.action == 'full' && github.ref == 'refs/heads/main' }}
@@ -434,7 +433,6 @@ jobs:
           aio_track="aio-v${release_revision}"
           gh workflow run "CI / Sure-AIO" \
             --ref main \
-            -f publish_image=true \
             -f run_smoke_test=false \
             -f aio_track_override="${aio_track}"
-          echo "Triggered CI / Sure-AIO workflow_dispatch with publish_image=true and aio_track_override=${aio_track}."
+          echo "Triggered CI / Sure-AIO workflow_dispatch on main with aio_track_override=${aio_track}."

--- a/scripts/ci_flags.py
+++ b/scripts/ci_flags.py
@@ -24,15 +24,15 @@ def resolve_flags(
     event_name: str,
     ref: str,
     run_smoke_test_input: str | None = None,
-    publish_image_input: str | None = None,
 ) -> CiFlags:
     if event_name == "push" and ref == "refs/heads/main":
         return CiFlags(run_smoke_requested=True, publish_requested=True)
 
-    if event_name == "workflow_dispatch":
+    if event_name == "workflow_dispatch" and ref == "refs/heads/main":
         return CiFlags(
             run_smoke_requested=parse_bool(run_smoke_test_input),
-            publish_requested=parse_bool(publish_image_input),
+            # Manual runs on main are explicitly for release/publish operations.
+            publish_requested=True,
         )
 
     return CiFlags(run_smoke_requested=False, publish_requested=False)
@@ -43,14 +43,12 @@ def main() -> int:
     parser.add_argument("--event-name", required=True)
     parser.add_argument("--ref", required=True)
     parser.add_argument("--run-smoke-test-input", default="")
-    parser.add_argument("--publish-image-input", default="")
     args = parser.parse_args()
 
     flags = resolve_flags(
         event_name=args.event_name,
         ref=args.ref,
         run_smoke_test_input=args.run_smoke_test_input,
-        publish_image_input=args.publish_image_input,
     )
     print(f"run_smoke_requested={'true' if flags.run_smoke_requested else 'false'}")
     print(f"publish_requested={'true' if flags.publish_requested else 'false'}")

--- a/scripts/test-ci-flags.py
+++ b/scripts/test-ci-flags.py
@@ -7,26 +7,26 @@ from ci_flags import resolve_flags
 def main() -> int:
     cases = [
         # push on main always enables smoke + publish for build-related changes
-        ("push", "refs/heads/main", "", "", True, True),
+        ("push", "refs/heads/main", "", True, True),
         # push on non-main should not force smoke/publish
-        ("push", "refs/heads/feature", "", "", False, False),
-        # workflow_dispatch should respect both boolean and string forms
-        ("workflow_dispatch", "refs/heads/main", "true", "true", True, True),
-        ("workflow_dispatch", "refs/heads/main", "1", "1", True, True),
-        ("workflow_dispatch", "refs/heads/main", "false", "true", False, True),
-        ("workflow_dispatch", "refs/heads/main", "", "true", False, True),
-        ("workflow_dispatch", "refs/heads/main", "true", "", True, False),
+        ("push", "refs/heads/feature", "", False, False),
+        # workflow_dispatch on main always publishes; smoke stays optional
+        ("workflow_dispatch", "refs/heads/main", "true", True, True),
+        ("workflow_dispatch", "refs/heads/main", "1", True, True),
+        ("workflow_dispatch", "refs/heads/main", "false", False, True),
+        ("workflow_dispatch", "refs/heads/main", "", False, True),
+        # workflow_dispatch on non-main should not publish
+        ("workflow_dispatch", "refs/heads/feature", "true", False, False),
         # PR events should never force smoke/publish from this resolver
-        ("pull_request", "refs/pull/1/merge", "", "", False, False),
+        ("pull_request", "refs/pull/1/merge", "", False, False),
     ]
 
     for idx, case in enumerate(cases, start=1):
-        event_name, ref, smoke_input, publish_input, expected_smoke, expected_publish = case
+        event_name, ref, smoke_input, expected_smoke, expected_publish = case
         result = resolve_flags(
             event_name=event_name,
             ref=ref,
             run_smoke_test_input=smoke_input,
-            publish_image_input=publish_input,
         )
         assert result.run_smoke_requested == expected_smoke, (
             f"case #{idx} expected run_smoke_requested={expected_smoke}, "


### PR DESCRIPTION
## Summary
Eliminates flaky manual publish behavior by making `CI / Sure-AIO` workflow-dispatch runs on `main` always execute the publish path, without relying on a sometimes-misread checkbox input.

## What changed
- remove `publish_image` input from `.github/workflows/build.yml`
- update CI gate resolver (`scripts/ci_flags.py`) so:
  - `push` on `main` => publish enabled
  - `workflow_dispatch` on `main` => publish enabled
  - `workflow_dispatch` on non-main => publish disabled
- keep `run_smoke_test` as optional/manual for dispatch runs
- update CI gate tests in `scripts/test-ci-flags.py` to cover the new dispatch semantics
- update `.github/workflows/release.yml` to stop passing removed `publish_image` input when triggering `CI / Sure-AIO`

## Why
- manual workflow runs were repeatedly completing with `publish` skipped even when users selected publish options
- this caused repeated operational failures and unnecessary maintenance loops
- deterministic dispatch behavior is required for reliable release operations

## Validation
- `python3 scripts/test-ci-flags.py`
- `python3 scripts/ci_flags.py --event-name workflow_dispatch --ref refs/heads/main --run-smoke-test-input false`
  - confirms `publish_requested=true`
- `PYTHONPYCACHEPREFIX=/tmp/sure-aio-pyc python3 -m py_compile scripts/ci_flags.py scripts/test-ci-flags.py scripts/release.py scripts/validate-template.py scripts/check-upstream.py scripts/update-template-changes.py`
- `python3 scripts/validate-template.py`

## Notes
- After merge, a manual `CI / Sure-AIO` run on `main` will publish by default.
- `run_smoke_test` remains optional.
- This does not create a new release/version; it fixes publish control flow reliability.
