### PR TITLE
build(image): harden bundled dependencies and refresh security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ USER root
 
 # 1. Install prerequisites, s6-overlay, Redis, and pgvector support
 # We use standard PATH binaries for Postgres (it's installed as postgresql)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Refresh inherited Debian packages before adding our own runtime dependencies so
+# published security fixes from the upstream base layer land in the wrapper image.
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
     build-essential ca-certificates curl git xz-utils \
     postgresql postgresql-client postgresql-server-dev-17 redis-server && \
     git clone --branch "v${PGVECTOR_VERSION}" --depth 1 https://github.com/pgvector/pgvector.git /tmp/pgvector && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ USER root
 RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
     build-essential ca-certificates curl git xz-utils \
     postgresql postgresql-client postgresql-server-dev-17 redis-server && \
+    cd /rails && \
+    bundle config set frozen false && \
+    bundle update --conservative rack rack-session addressable rexml && \
+    bundle clean --force && \
+    bundle config set frozen true && \
     git clone --branch "v${PGVECTOR_VERSION}" --depth 1 https://github.com/pgvector/pgvector.git /tmp/pgvector && \
     make -C /tmp/pgvector OPTFLAGS="" && \
     make -C /tmp/pgvector install && \


### PR DESCRIPTION
## Summary
Reduce wrapper-owned image vulnerabilities by refreshing inherited Debian packages and patching safely updatable bundled Ruby dependencies without removing features or changing the AIO deployment model.

## What changed
- run `apt-get -y dist-upgrade` during image build so published Debian security updates from the inherited base layer are applied in the wrapper image
- update bundled Ruby dependencies conservatively during build:
  - `rack`
  - `rack-session`
  - `addressable`
  - `rexml`
- run `bundle clean --force` after the dependency refresh so stale vulnerable gem versions are removed from the final image
- preserve the existing AIO runtime model and bundled services

## Why
- Docker Scout was reporting a large number of image vulnerabilities, including wrapper-fixable Ruby dependency findings
- the final image still contained old vulnerable gem versions even after bundle updates unless they were explicitly cleaned
- this repo should fix everything safely fixable in the wrapper layer before pushing remaining findings upstream

## Validation
- built locally: `docker build --platform linux/amd64 -t sure-aio:security-pass3 .`
- scanned locally with Docker Scout:
  - `docker scout quickview sure-aio:security-pass3`
  - `docker scout cves --only-severity critical,high sure-aio:security-pass3`
- ran local smoke test successfully:
  - `bash -x ./scripts/smoke-test.sh sure-aio:security-pass3`

## Notes
- this reduced the local Scout result from `4 critical / 19 high` to `3 critical / 15 high`
- remaining high/critical findings are primarily Debian packages with no published fixed version yet (`libraw`, `openexr`, `imagemagick`, `libde265`, `nghttp2`) plus likely advisory noise for Rails 8-only ranges reported against Rails 7 packages
- this PR does not remove image-processing libraries or other runtime features, because doing so would risk breaking Sure functionality
