### PR TITLE
ci(release): standardize fleet publish and validation flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,7 +376,7 @@ jobs:
         run: exit 1
 
   publish:
-    if: ${{ (needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.xml_related == 'true') && vars.ENABLE_AIO_AUTOMATION == 'true' && github.event_name == 'push' && needs.detect-changes.outputs.publish_requested == 'true' && needs.integration-tests.result == 'success' }}
+    if: ${{ (needs.detect-changes.outputs.build_related == 'true' || needs.detect-changes.outputs.xml_related == 'true') && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.publish_requested == 'true' && needs.integration-tests.result == 'success' }}
     needs:
       - detect-changes
       - validate-template
@@ -511,7 +511,7 @@ jobs:
           load: false
 
   sync-awesome-unraid:
-    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.detect-changes.outputs.xml_related == 'true' && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     needs:
       - detect-changes
       - validate-template

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,10 +33,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_COMMIT: ${{ steps.version.outputs.release_commit }}
-          WORKFLOW_NAME: CI / Sure-AIO
+          WORKFLOW_SELECTOR: build.yml
         run: |
           runs_json="$(gh run list \
-            --workflow "${WORKFLOW_NAME}" \
+            --workflow "${WORKFLOW_SELECTOR}" \
             --commit "${RELEASE_COMMIT}" \
             --limit 20 \
             --json databaseId,headSha,status,conclusion)"
@@ -62,7 +62,7 @@ jobs:
               sys.exit(0)
 
           print(
-              f"No successful '{os.environ['WORKFLOW_NAME']}' run was found for release commit {release_commit}.",
+              f"No successful workflow run was found for release commit {release_commit} using selector {os.environ['WORKFLOW_SELECTOR']}.",
               file=sys.stderr,
           )
           sys.exit(1)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -21,25 +21,9 @@ Every `main` build publishes:
 
 ## Release flow
 
-1. Trigger **Release / Sure-AIO** from `main` with `action=prepare`.
-2. The workflow computes the next `upstream-aio.N` version and opens a release PR.
+1. Trigger **Prepare Release / Sure-AIO** from `main`.
+2. The workflow computes the next `upstream-aio.N` version, updates `CHANGELOG.md`, syncs the XML `<Changes>` block, and opens a release PR.
 3. Review and merge that PR into `main`.
-4. Trigger **Release / Sure-AIO** from `main` again with `action=publish`.
-5. The workflow reads the merged `CHANGELOG.md` entry, creates the Git tag, and publishes the GitHub Release.
-6. The same publish job automatically dispatches **CI / Sure-AIO** (`workflow_dispatch`) with `publish_image=true` so GHCR package tags (including `upstream-aio-vN`) stay aligned with the new release revision.
-   It now passes an explicit `aio_track_override` derived from the release version (for example `v0.6.9-aio.3` -> `aio-v3`) to prevent tag drift.
-
-## One-dispatch mode
-
-You can run the same workflow with `action=full` for one-dispatch orchestration:
-
-1. Creates/updates the release PR from `CHANGELOG.md` generation.
-2. Enables auto-merge on that PR.
-3. Waits for merge to complete.
-4. Creates the Git tag and publishes the GitHub Release.
-5. Dispatches **CI / Sure-AIO** with `publish_image=true` to publish GHCR tags.
-
-Notes:
-
-- `action=full` defaults `auto_merge_release_pr=true` and will attempt GitHub auto-merge first.
-- If repository auto-merge is disabled, the workflow automatically falls back to direct merge polling and proceeds once required checks/policies allow merge.
+4. Wait for the `CI / Sure-AIO` run on the release commit to finish green. That same `main` push also publishes the updated package tags automatically.
+5. Trigger **Publish Release / Sure-AIO** from `main`.
+6. The workflow verifies CI on the exact release commit, creates the Git tag if needed, and publishes the GitHub Release.

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -23,7 +23,7 @@ require_absent() {
 check_no_placeholder() {
 	local pattern="$1"
 	shift
-	if rg -n --fixed-strings "${pattern}" "$@" >/dev/null 2>&1; then
+	if grep -F -n -- "${pattern}" "$@" >/dev/null 2>&1; then
 		fail "found unresolved placeholder '${pattern}' in: $*"
 	fi
 }
@@ -68,7 +68,7 @@ if [[ -z ${effective_template_xml} ]]; then
 fi
 
 is_template_repo="false"
-if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+if [[ -f .github/workflows/publish-release.yml ]] && grep -F -q -- "Publish Release / Template" .github/workflows/publish-release.yml; then
 	is_template_repo="true"
 fi
 

--- a/scripts/validate-derived-repo.sh
+++ b/scripts/validate-derived-repo.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 repo_root="${1:-.}"
 cd "${repo_root}"
-strict_placeholders="${STRICT_PLACEHOLDERS:-${ENABLE_AIO_AUTOMATION:-false}}"
+strict_placeholders="${STRICT_PLACEHOLDERS:-false}"
 
 fail() {
 	echo "template validation error: $*" >&2
@@ -17,7 +17,7 @@ require_file() {
 
 require_absent() {
 	local path="$1"
-	[[ ! -e ${path} ]] || fail "remove template placeholder path before enabling automation: ${path}"
+	[[ ! -e ${path} ]] || fail "remove template placeholder path in derived repo: ${path}"
 }
 
 check_no_placeholder() {
@@ -67,10 +67,16 @@ if [[ -z ${effective_template_xml} ]]; then
 	fi
 fi
 
-if [[ ${ENABLE_AIO_AUTOMATION-} == "true" ]]; then
-	[[ -n ${effective_template_xml} ]] || fail "ENABLE_AIO_AUTOMATION=true requires a root XML file"
+is_template_repo="false"
+if [[ -f .github/workflows/publish-release.yml ]] && rg -q --fixed-strings "Publish Release / Template" .github/workflows/publish-release.yml; then
+	is_template_repo="true"
+fi
+
+if [[ -n ${effective_template_xml} ]]; then
 	require_file "${effective_template_xml}"
-	require_absent "template-aio.xml"
+	if [[ ${is_template_repo} != "true" ]]; then
+		require_absent "template-aio.xml"
+	fi
 fi
 
 xml_files=()


### PR DESCRIPTION
## Summary
- remove the unused automation flag and align release-triggered publishing with the fleet baseline

## What changed
- remove `ENABLE_AIO_AUTOMATION` gating from workflow behavior and validation helpers
- make publish jobs explicitly require `push` to `main`
- update release docs to the current prepare-then-publish flow

## Why
- the fleet does not use `ENABLE_AIO_AUTOMATION`
- release/package behavior should be explicit and consistent across repos

## Validation
- `trunk check --show-existing --all`
- `python3 scripts/validate-template.py`
- `pytest tests/unit tests/template`
- `pytest tests/integration -m integration`
- `pytest tests/unit tests/template --junit-xml=reports/pytest-unit.xml -o junit_family=xunit1`
- `pytest tests/integration -m integration --junit-xml=reports/pytest-integration.xml -o junit_family=xunit1`
- `/tmp/trunk-analytics-cli/trunk-analytics-cli validate --junit-paths "reports/pytest-unit.xml,reports/pytest-integration.xml"`
- `git diff --check`
