### PR TITLE
ci(fleet): use shared AIO workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@337b82e04d6d1b887c704326a967bb1b10416752
     permissions:
       contents: read
       packages: write
@@ -75,6 +75,7 @@ jobs:
       extended_integration_pytest_args: ""
       generator_check_command: ""
       upstream_digest_arg: UPSTREAM_IMAGE_DIGEST
+      catalog_published: true
       xml_paths: |
         sure-aio.xml
       extra_publish_paths: |

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@337b82e04d6d1b887c704326a967bb1b10416752
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@337b82e04d6d1b887c704326a967bb1b10416752
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ba033c4af5d16e7fcb4962f77e527eb5d86782fa
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@337b82e04d6d1b887c704326a967bb1b10416752
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Converts this repository to the shared AIO fleet workflows.

## What changed
- Replaces duplicated build, upstream-check, and release workflow logic with pinned aio-fleet reusable workflows
- Keeps repo-specific inputs in small local caller workflows

## Why
- Centralizes CI, publish gates, upstream monitoring, release preparation, Docker cache behavior, and catalog sync behavior across the AIO fleet

## Validation
- Generated from JSONbored/aio-fleet manifest
