### PR TITLE
ci(fleet): sync catalog publication state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@01163d070460034ea975df7b57d34b6178f33e97
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@01163d070460034ea975df7b57d34b6178f33e97
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@01163d070460034ea975df7b57d34b6178f33e97
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@01163d070460034ea975df7b57d34b6178f33e97
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@c4099c09cb2375a0f5a5a822a0f8af02a77d0526
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Updates this repository's thin AIO workflow callers to the latest aio-fleet manifest pin.

## What changed
- Bumps the aio-fleet reusable workflow ref to c4099c09cb2375a0f5a5a822a0f8af02a77d0526.
- Carries the current fleet manifest inputs into the local caller workflows.

## Why
- Keeps caller workflows aligned with the control-plane manifest after Dify was marked catalog-published.

## Validation
- Generated from JSONbored/aio-fleet manifest after aio-fleet#11.

## Notes
- Local SSH commit signing is blocked in this session because the Strongbox agent exposes no signing identities; this branch commit was created unsigned, and the PR should be squash-merged through GitHub.
