### PR TITLE
ci(publish): pin Docker Hub primary workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ concurrency:
 
 jobs:
   aio-build:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-build.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check-upstream:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-check-upstream.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   publish-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-publish-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ce6221adb01de3fbe16b40fa0274c950c1ccd225
+    uses: JSONbored/aio-fleet/.github/workflows/aio-prepare-release.yml@ca2c2a32968e0c6d05f0fe270db6a6a48fb32dbf
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- repin caller workflows to the Docker Hub-primary aio-fleet reusable workflow
- keep this repo aligned with the shared publish contract

## Validation
- scripts/validate-template.py
- pytest tests/template