### PR TITLE
chore(release): 0.7.0-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## 0.7.0-aio.1 - 2026-05-01
+### CI
+- Use shared AIO workflows (#62)
+- Pin shared validation policy
+- Use shared AIO workflows
+- Sync workflow path filters
+- Sync catalog publication state
+- Pin publish helper workflow fix
+- Pin Docker Hub primary workflow
+
+
+### Dependency Updates
+- Update Sure to v0.7.0
+
+
+### Features
+- Expose manual publish targets
+
+
+### Fixes
+- Sync shared validation and trunk cleanup
+- Sync release shim path fallback
+- Expose sure v0.7 runtime options
+- Expose Sure v0.7 runtime options (#78)
+
+
+### Maintenance
+- Sync shared repository boilerplate
+
+
+### Refactors
+- Use shared derived repo validation
+- Use shared release helper shim
+
+
+### Tests
+- Use shared runtime contract helpers
+
 
 ## v0.6.9-aio.5 - 2026-04-25
 

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,13 +31,25 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-04-25&#xD;
+  <Changes>### 2026-05-01&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Optimize pytest gating and Trunk uploads (#56)&#xD;
-- Standardize fleet publish and validation flow (#57)&#xD;
-- Centralize trunk config and gate release tags (#58)&#xD;
-- Consolidate pytest workflow steps (#60)&#xD;
-- Pin package tags to release targets (#59)</Changes>
+- Use shared AIO workflows (#62)&#xD;
+- Pin shared validation policy&#xD;
+- Use shared AIO workflows&#xD;
+- Sync workflow path filters&#xD;
+- Sync catalog publication state&#xD;
+- Pin publish helper workflow fix&#xD;
+- Pin Docker Hub primary workflow&#xD;
+- Update Sure to v0.7.0&#xD;
+- Expose manual publish targets&#xD;
+- Sync shared validation and trunk cleanup&#xD;
+- Sync release shim path fallback&#xD;
+- Expose sure v0.7 runtime options&#xD;
+- Expose Sure v0.7 runtime options (#78)&#xD;
+- Sync shared repository boilerplate&#xD;
+- Use shared derived repo validation&#xD;
+- Use shared release helper shim&#xD;
+- Use shared runtime contract helpers</Changes>
   <Category>Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
This PR prepares `0.7.0-aio.1` for `Sure-AIO`.

## Summary
- updates `CHANGELOG.md` with `git-cliff`
- syncs `sure-aio.xml` `<Changes>` from `CHANGELOG.md`
- removes the bad `.aio-fleet` helper gitlink from the failed generated branch
- is rebased onto the merged control-plane workflow pin so publish uses dual Docker Hub plus GHCR support
- is intended to be merged to `main`
- requires a separate manual `Publish Release / Sure-AIO` run after merge

## Validation
- `.venv/bin/python scripts/validate-template.py --all`
- `.venv/bin/python -m pytest tests/unit tests/template -q`
- `git diff --check main..HEAD`

## Notes
- The original Prepare Release run failed because the consolidated reusable workflow selected `RELEASE_TOKEN`, which could push the branch but could not create the PR.
- The permanent prepare-release fix landed in JSONbored/aio-fleet#25 and is now pinned in Sure-AIO via JSONbored/sure-aio#81.