### PR TITLE
chore(sync): format fleet manifest and changelog

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -16,13 +16,13 @@ upstream:
   digest_arg: UPSTREAM_IMAGE_DIGEST
 template:
   xml_paths:
-  - sure-aio.xml
+    - sure-aio.xml
   generated: false
 catalog:
   published: true
   assets:
-  - source: sure-aio.xml
-    target: sure-aio.xml
+    - source: sure-aio.xml
+      target: sure-aio.xml
 tests:
   unit: tests/unit tests/template
   integration: tests/integration -m integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## 0.7.0-aio.1 - 2026-05-01
+
 ### CI
+
 - Use shared AIO workflows (#62)
 - Pin shared validation policy
 - Use shared AIO workflows
@@ -11,34 +14,33 @@ All notable changes to this project will be documented in this file.
 - Pin publish helper workflow fix
 - Pin Docker Hub primary workflow
 
-
 ### Dependency Updates
+
 - Update Sure to v0.7.0
 
-
 ### Features
+
 - Expose manual publish targets
 
-
 ### Fixes
+
 - Sync shared validation and trunk cleanup
 - Sync release shim path fallback
 - Expose sure v0.7 runtime options
 - Expose Sure v0.7 runtime options (#78)
 
-
 ### Maintenance
+
 - Sync shared repository boilerplate
 
-
 ### Refactors
+
 - Use shared derived repo validation
 - Use shared release helper shim
 
-
 ### Tests
-- Use shared runtime contract helpers
 
+- Use shared runtime contract helpers
 
 ## v0.6.9-aio.5 - 2026-04-25
 


### PR DESCRIPTION
## Summary
- Format `.aio-fleet.yml` and `CHANGELOG.md` so Sure passes the central aio-fleet Trunk overlay.

## What changed
- Indented manifest lists in `.aio-fleet.yml` using the central Prettier style.
- Normalized changelog spacing without changing release content.

## Why
- The new aio-fleet central control check runs Trunk from a scratch checkout with the fleet-owned `.trunk` config. Sure needed these formatting fixes before it can be used as the GitHub App check-run pilot.

## Validation
- `.venv/bin/python scripts/validate-template.py --all`
- `scripts/validate-derived-repo.sh .`
- `.venv/bin/python -m pytest tests/unit tests/template -q`
- `trunk check --show-existing --all --no-fix --no-progress --color=false`
- from aio-fleet: `.venv/bin/python -m aio_fleet control-check --repo sure-aio --sha f93c8ffab847c4ad87cfca967957ea2e9050b180 --event pull_request`

## Notes
- This does not remove app-local workflows or release scripts yet; that cleanup remains gated on the GitHub App check-run and branch-protection migration.