### PR TITLE
chore(sync): refresh aio-fleet manifest

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -18,7 +18,7 @@ upstream:
   monitor:
     - component: aio
       name: Sure
-      source: github-tags
+      source: github-releases
       repo: we-promise/sure
       image: we-promise/sure
       digest_source: ghcr


### PR DESCRIPTION
## Summary
- refreshes the generated `.aio-fleet.yml` from the current `aio-fleet` manifest

## What changed
- switches Sure upstream monitoring to `github-releases` in the app-local fleet manifest
- normalizes the generated category quoting from the exporter

## Why
- central validation flagged `.aio-fleet.yml` drift after the Sure hotfix-release detection migration

## Validation
- from `aio-fleet`: `.venv/bin/python -m aio_fleet validate --all`
- from `aio-fleet`: `.venv/bin/python -m aio_fleet cleanup-repo --all --verify`

## Notes
- no runtime, template, or image behavior changed in `sure-aio`
