### PR TITLE
chore(release): 0.7.0-hotfix.2-aio.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.0-hotfix.2-aio.2 - 2026-05-06
+
+### Fixes
+
+- Align sure version display with upstream tag
+
 ## 0.7.0-hotfix.2-aio.1 - 2026-05-05
 
 ### Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG UPSTREAM_IMAGE_DIGEST=sha256:10ee972ce59ef6c409e973641ece639be419cb533ed74b3
 ARG PGVECTOR_VERSION=0.8.2
 FROM ghcr.io/we-promise/sure:${UPSTREAM_VERSION}@${UPSTREAM_IMAGE_DIGEST}
 
+ARG UPSTREAM_VERSION
 ARG PGVECTOR_VERSION
 ARG S6_OVERLAY_VERSION=3.1.6.2
 ARG S6_OVERLAY_NOARCH_SHA256=05af2536ec4fb23f087a43ce305f8962512890d7c71572ed88852ab91d1434e3
@@ -17,6 +18,10 @@ ARG TARGETARCH
 USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /rails
+
+# Upstream hotfix images can lag their release tag in this file, but Sure's UI
+# reports the version from it.
+RUN printf '%s\n' "${UPSTREAM_VERSION}" > /rails/.sure-version
 
 # 1. Install prerequisites, s6-overlay, Redis, and pgvector support
 # We use standard PATH binaries for Postgres (it's installed as postgresql)

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,18 +31,9 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-05-05&#xD;
+  <Changes>### 2026-05-06&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Harden apt package installs&#xD;
-- Document central app test dependencies&#xD;
-- Format fleet manifest and changelog&#xD;
-- Move shared automation to aio-fleet&#xD;
-- Declare aio-fleet ownership&#xD;
-- Bump sure to 0.7.0-hotfix.1&#xD;
-- Refresh aio-fleet manifest&#xD;
-- Bump sure to 0.7.0-hotfix.2&#xD;
-- Refresh sure 0.7.0-hotfix.2 digest&#xD;
-- Remove legacy shared contract tests</Changes>
+- Align sure version display with upstream tag</Changes>
   <Category>Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from contextlib import contextmanager
@@ -7,6 +8,7 @@ from contextlib import contextmanager
 import pytest
 
 from tests.helpers import (
+    REPO_ROOT,
     container_path_exists,
     docker_available,
     docker_volume,
@@ -17,6 +19,13 @@ from tests.helpers import (
 
 IMAGE_TAG = "sure-aio:pytest"
 pytestmark = pytest.mark.integration
+
+
+def pinned_upstream_version() -> str:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text()
+    match = re.search(r"^ARG UPSTREAM_VERSION=(?P<version>\S+)$", dockerfile, re.M)
+    assert match is not None  # nosec B101
+    return match.group("version")
 
 
 def logs(name: str) -> str:
@@ -177,3 +186,19 @@ def test_happy_path_boot_and_recreate_persists_data() -> None:
             assert (
                 "export: fatal: invalid variable name" not in second_logs
             )  # nosec B101
+
+
+def test_image_reports_pinned_upstream_version() -> None:
+    result = run_command(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "cat",
+            IMAGE_TAG,
+            "/rails/.sure-version",
+        ]
+    )
+
+    assert result.stdout.strip() == pinned_upstream_version()  # nosec B101


### PR DESCRIPTION
## Summary
- patch the wrapper image so `/rails/.sure-version` matches the pinned upstream Sure tag
- add Docker-backed coverage for the version file displayed by the app
- prepare the `0.7.0-hotfix.2-aio.2` release metadata and XML `<Changes>`

## What changed
- Docker build writes `/rails/.sure-version` from `UPSTREAM_VERSION`
- integration tests assert the built image reports the Dockerfile `UPSTREAM_VERSION`
- changelog and source XML were generated through `aio-fleet release prepare`

## Why
Upstream `v0.7.0-hotfix.2` still ships `.sure-version` as `0.7.0-hotfix.1`, so the app UI can show the stale version even when the wrapper image is built from the hotfix.2 upstream image.

## Validation
- `aio-fleet validate-repo --repo sure-aio --repo-path /Users/shadowbook/Documents/sure-aio`
- `aio-fleet validate-template-common --repo sure-aio --repo-path /Users/shadowbook/Documents/sure-aio`
- `aio-fleet trunk run --repo sure-aio --repo-path /Users/shadowbook/Documents/sure-aio --no-fix`
- `.venv/bin/python -m pytest tests/integration -m integration -q` (2 passed)
- `docker run --rm --entrypoint cat sure-aio:pytest /rails/.sure-version` -> `0.7.0-hotfix.2`

## Notes
Merge this after the `aio-fleet` publish-gate PR so the release publish path uses the fixed central poll behavior.
