### PR TITLE
test(smoke): harden sure alpha runtime coverage

### DIFF
--- a/docs/alpha-lane.md
+++ b/docs/alpha-lane.md
@@ -13,6 +13,8 @@ The alpha Unraid template exposes upstream alpha-only self-hosting controls when
 
 These are not wrapper patches. They belong to upstream Sure's passkey/WebAuthn MFA alpha work and are shown in the alpha template only until the feature stabilizes.
 
+The alpha XML changelog must call out exposed upstream alpha controls separately from wrapper patches so users can tell what came from Sure and what came from AIO.
+
 ## Patch Ledger
 
 ### import-limits-env
@@ -30,3 +32,9 @@ These are not wrapper patches. They belong to upstream Sure's passkey/WebAuthn M
 - Prefer environment-driven Rails initializers over direct source patches because they survive daily alpha image bumps better.
 - Use `patches/sure-alpha/` only when an initializer cannot hook the behavior cleanly.
 - If an upstream alpha bump breaks an overlay, validation should fail before the alpha image is published.
+
+## Validation Expectations
+
+- XML tests must keep stable `sure-aio` free of alpha-only variables.
+- XML tests must verify the beta marker, separate image/template identity, separate appdata paths, import controls, WebAuthn controls, and alpha changelog text.
+- Runtime tests must boot the alpha image and verify `/up`, `/rails/.sure-version`, import limit defaults/overrides/fallback behavior, and WebAuthn environment parsing inside Rails.

--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -31,7 +31,11 @@ This template is meant for testing and local validation, not primary household f
 - [code]/mnt/user/appdata/sure-aio-alpha/redis[/code]</Overview>
   <Changes>### 2026-05-17&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Add Sure AIO Alpha testing lane with configurable import limits</Changes>
+- Add Sure AIO Alpha testing lane tracking upstream Sure alpha prereleases.&#xD;
+- Publish alpha images separately as [code]jsonbored/sure-aio-alpha:latest-alpha[/code], upstream alpha version tags, and commit SHA tags.&#xD;
+- Mark the template as beta/testing with a separate app name, default Web UI port, and appdata root from stable [code]sure-aio[/code].&#xD;
+- Add alpha-only import limit controls: [code]SURE_IMPORT_MAX_NDJSON_SIZE_MB[/code] defaults to [code]250[/code], and [code]SURE_IMPORT_MAX_ROWS[/code] defaults to [code]1000000[/code].&#xD;
+- Expose upstream alpha passkey/WebAuthn controls: [code]WEBAUTHN_RP_ID[/code] and [code]WEBAUTHN_ALLOWED_ORIGINS[/code].</Changes>
   <Category>Productivity: Tools:Utilities</Category>
   <Beta>True</Beta>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -21,6 +21,9 @@ from tests.helpers import (
 IMAGE_TAG = "sure-aio:pytest"
 ALPHA_IMAGE_TAG = "sure-aio-alpha:pytest"
 pytestmark = pytest.mark.integration
+SECRET_KEY_BASE = (
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"  # nosec B105
+)
 
 
 def pinned_upstream_version(dockerfile_name: str = "Dockerfile") -> str:
@@ -69,6 +72,26 @@ def assert_no_https_redirect(host_port: int) -> None:
     assert "location: https://" not in result.stdout.lower()  # nosec B101
 
 
+def rails_runner_output(container_name: str, code: str) -> str:
+    result = docker_exec(container_name, f"bin/rails runner {code!r}")
+    lines = result.stdout.strip().splitlines()
+    return lines[-1] if lines else ""
+
+
+def assert_alpha_import_and_webauthn_config(
+    container_name: str,
+    expected: str,
+) -> None:
+    result = rails_runner_output(
+        container_name,
+        "config = Rails.application.config.x.webauthn; "
+        "puts [SureImport::MAX_NDJSON_SIZE, SureImport.max_ndjson_size, "
+        "SureImport.max_row_count, SureImport.allocate.max_row_count, "
+        'config.rp_id, config.allowed_origins.join("|")].join(":")',
+    )
+    assert result == expected  # nosec B101
+
+
 @contextmanager
 def container(
     storage_volume: str,
@@ -81,9 +104,6 @@ def container(
 ):
     name = f"{name_prefix}-{uuid.uuid4().hex[:10]}"
     host_port = reserve_host_port()
-    secret = (
-        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"  # nosec B105
-    )
     v0_7_runtime_env = {
         "ALPHA_VANTAGE_MAX_REQUESTS_PER_DAY": "25",
         "BINANCE_EGRESS_IP": "127.0.0.1",
@@ -116,7 +136,7 @@ def container(
         "-p",
         f"{host_port}:3000",
         "-e",
-        f"SECRET_KEY_BASE={secret}",
+        f"SECRET_KEY_BASE={SECRET_KEY_BASE}",
         "-e",
         "SELF_HOSTED=true",
         "-e",
@@ -226,7 +246,9 @@ def test_image_reports_pinned_upstream_version(build_image) -> None:
     assert result.stdout.strip() == pinned_upstream_version()  # nosec B101
 
 
-def test_alpha_image_reports_version_and_import_limits(build_alpha_image) -> None:
+def test_alpha_image_boots_with_version_import_limits_and_webauthn_env(
+    build_alpha_image,
+) -> None:
     with (
         docker_volume("sure-aio-alpha-storage") as storage_volume,
         docker_volume("sure-aio-alpha-pg") as pgdata_volume,
@@ -241,6 +263,10 @@ def test_alpha_image_reports_version_and_import_limits(build_alpha_image) -> Non
             extra_env={
                 "SURE_IMPORT_MAX_NDJSON_SIZE_MB": "250",
                 "SURE_IMPORT_MAX_ROWS": "1000000",
+                "WEBAUTHN_RP_ID": "finance.example.com",
+                "WEBAUTHN_ALLOWED_ORIGINS": (
+                    "https://finance.example.com,https://sure.example.net"
+                ),
             },
         ) as (
             name,
@@ -249,10 +275,113 @@ def test_alpha_image_reports_version_and_import_limits(build_alpha_image) -> Non
             wait_for_http(name, host_port)
             version = docker_exec(name, "cat /rails/.sure-version").stdout.strip()
             assert version == pinned_upstream_version("Dockerfile.alpha")  # nosec B101
-            result = docker_exec(
+            assert_alpha_import_and_webauthn_config(
                 name,
-                "bin/rails runner 'puts [SureImport::MAX_NDJSON_SIZE, SureImport.max_ndjson_size, SureImport.max_row_count].join(\":\" )'",
+                (
+                    "262144000:262144000:1000000:1000000:"
+                    "finance.example.com:"
+                    "https://finance.example.com|https://sure.example.net"
+                ),
             )
-            assert result.stdout.strip().splitlines()[-1] == (  # nosec B101
-                "262144000:262144000:1000000"
+
+
+def test_alpha_import_limit_defaults_are_runtime_defaults(build_alpha_image) -> None:
+    with (
+        docker_volume("sure-aio-alpha-default-storage") as storage_volume,
+        docker_volume("sure-aio-alpha-default-pg") as pgdata_volume,
+        docker_volume("sure-aio-alpha-default-redis") as redis_volume,
+    ):
+        with container(
+            storage_volume,
+            pgdata_volume,
+            redis_volume,
+            image_tag=ALPHA_IMAGE_TAG,
+            name_prefix="sure-aio-alpha-default-pytest",
+        ) as (name, host_port):
+            wait_for_http(name, host_port)
+            assert_alpha_import_and_webauthn_config(
+                name,
+                "262144000:262144000:1000000:1000000:localhost:"
+                "http://localhost:3000",
+            )
+
+
+def test_alpha_import_limit_env_overrides_are_applied(build_alpha_image) -> None:
+    with (
+        docker_volume("sure-aio-alpha-custom-storage") as storage_volume,
+        docker_volume("sure-aio-alpha-custom-pg") as pgdata_volume,
+        docker_volume("sure-aio-alpha-custom-redis") as redis_volume,
+    ):
+        with container(
+            storage_volume,
+            pgdata_volume,
+            redis_volume,
+            image_tag=ALPHA_IMAGE_TAG,
+            name_prefix="sure-aio-alpha-custom-pytest",
+            extra_env={
+                "SURE_IMPORT_MAX_NDJSON_SIZE_MB": "12",
+                "SURE_IMPORT_MAX_ROWS": "3456",
+            },
+        ) as (name, host_port):
+            wait_for_http(name, host_port)
+            assert_alpha_import_and_webauthn_config(
+                name,
+                "12582912:12582912:3456:3456:localhost:http://localhost:3000",
+            )
+
+
+def test_alpha_import_limit_invalid_env_falls_back_to_defaults(
+    build_alpha_image,
+) -> None:
+    with (
+        docker_volume("sure-aio-alpha-invalid-storage") as storage_volume,
+        docker_volume("sure-aio-alpha-invalid-pg") as pgdata_volume,
+        docker_volume("sure-aio-alpha-invalid-redis") as redis_volume,
+    ):
+        with container(
+            storage_volume,
+            pgdata_volume,
+            redis_volume,
+            image_tag=ALPHA_IMAGE_TAG,
+            name_prefix="sure-aio-alpha-invalid-pytest",
+            extra_env={
+                "SURE_IMPORT_MAX_NDJSON_SIZE_MB": "0",
+                "SURE_IMPORT_MAX_ROWS": "not-a-number",
+            },
+        ) as (name, host_port):
+            wait_for_http(name, host_port)
+            assert_alpha_import_and_webauthn_config(
+                name,
+                "262144000:262144000:1000000:1000000:localhost:"
+                "http://localhost:3000",
+            )
+
+
+def test_alpha_webauthn_env_is_parsed_by_upstream_initializer(
+    build_alpha_image,
+) -> None:
+    with (
+        docker_volume("sure-aio-alpha-webauthn-storage") as storage_volume,
+        docker_volume("sure-aio-alpha-webauthn-pg") as pgdata_volume,
+        docker_volume("sure-aio-alpha-webauthn-redis") as redis_volume,
+    ):
+        with container(
+            storage_volume,
+            pgdata_volume,
+            redis_volume,
+            image_tag=ALPHA_IMAGE_TAG,
+            name_prefix="sure-aio-alpha-webauthn-pytest",
+            extra_env={
+                "WEBAUTHN_RP_ID": "https://finance.example.com:443/settings",
+                "WEBAUTHN_ALLOWED_ORIGINS": (
+                    "https://finance.example.com/, https://sure.example.net"
+                ),
+            },
+        ) as (name, host_port):
+            wait_for_http(name, host_port)
+            assert_alpha_import_and_webauthn_config(
+                name,
+                "262144000:262144000:1000000:1000000:"
+                "finance.example.com:"
+                "https://finance.example.com|https://sure.example.net",
             )

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -49,28 +49,58 @@ def test_alpha_template_has_separate_identity_and_storage() -> None:
         path.startswith("/mnt/user/appdata/sure-aio-alpha/")
         for path in _host_paths(alpha)
     )
+    assert "Testing / Unstable" in alpha.findtext("Overview", "")  # nosec B101
+    assert "stable [code]sure-aio[/code] appdata" in alpha.findtext(  # nosec B101
+        "Overview", ""
+    )
 
 
 def test_alpha_template_declares_import_limit_controls() -> None:
     stable_targets = _config_targets(_xml_root("sure-aio.xml"))
     alpha_targets = _config_targets(_xml_root("sure-aio-alpha.xml"))
+    ndjson = alpha_targets["SURE_IMPORT_MAX_NDJSON_SIZE_MB"]
+    rows = alpha_targets["SURE_IMPORT_MAX_ROWS"]
 
     assert "SURE_IMPORT_MAX_NDJSON_SIZE_MB" not in stable_targets  # nosec B101
     assert "SURE_IMPORT_MAX_ROWS" not in stable_targets  # nosec B101
-    assert alpha_targets["SURE_IMPORT_MAX_NDJSON_SIZE_MB"].text == "250"  # nosec B101
-    assert alpha_targets["SURE_IMPORT_MAX_ROWS"].text == "1000000"  # nosec B101
+    assert ndjson.text == "250"  # nosec B101
+    assert ndjson.get("Default") == "250"  # nosec B101
+    assert ndjson.get("Display") == "always"  # nosec B101
+    assert ndjson.get("Required") == "false"  # nosec B101
+    assert ndjson.get("Mask") == "false"  # nosec B101
+    assert "Alpha-only" in ndjson.get("Description", "")  # nosec B101
+    assert rows.text == "1000000"  # nosec B101
+    assert rows.get("Default") == "1000000"  # nosec B101
+    assert rows.get("Display") == "always"  # nosec B101
+    assert rows.get("Required") == "false"  # nosec B101
+    assert rows.get("Mask") == "false"  # nosec B101
+    assert "web, API, and preflight" in rows.get("Description", "")  # nosec B101
     assert alpha_targets["3000"].text == "3001"  # nosec B101
 
 
 def test_alpha_template_exposes_upstream_alpha_webauthn_controls() -> None:
     stable_targets = _config_targets(_xml_root("sure-aio.xml"))
     alpha_targets = _config_targets(_xml_root("sure-aio-alpha.xml"))
+    rp_id = alpha_targets["WEBAUTHN_RP_ID"]
+    origins = alpha_targets["WEBAUTHN_ALLOWED_ORIGINS"]
 
     assert "WEBAUTHN_RP_ID" not in stable_targets  # nosec B101
     assert "WEBAUTHN_ALLOWED_ORIGINS" not in stable_targets  # nosec B101
-    assert alpha_targets["WEBAUTHN_RP_ID"].get("Display") == "advanced"  # nosec B101
-    assert (  # nosec B101
-        alpha_targets["WEBAUTHN_ALLOWED_ORIGINS"].get("Display") == "advanced"
+    assert rp_id.get("Default") == ""  # nosec B101
+    assert rp_id.text in (None, "")  # nosec B101
+    assert rp_id.get("Display") == "advanced"  # nosec B101
+    assert rp_id.get("Required") == "false"  # nosec B101
+    assert rp_id.get("Mask") == "false"  # nosec B101
+    assert "passkey/WebAuthn relying party ID" in rp_id.get(  # nosec B101
+        "Description", ""
+    )
+    assert origins.get("Default") == ""  # nosec B101
+    assert origins.text in (None, "")  # nosec B101
+    assert origins.get("Display") == "advanced"  # nosec B101
+    assert origins.get("Required") == "false"  # nosec B101
+    assert origins.get("Mask") == "false"  # nosec B101
+    assert "comma-separated WebAuthn origins" in origins.get(  # nosec B101
+        "Description", ""
     )
 
 
@@ -88,3 +118,18 @@ def test_alpha_overlay_is_documented_and_copied() -> None:
     assert "SURE_IMPORT_MAX_ROWS" in text  # nosec B101
     assert "SureImport.const_set(:MAX_NDJSON_SIZE" in text  # nosec B101
     assert "import-limits-env" in ledger  # nosec B101
+
+
+def test_alpha_changelog_documents_runtime_differences() -> None:
+    alpha = _xml_root("sure-aio-alpha.xml")
+    changes = alpha.findtext("Changes", "")
+
+    assert "upstream Sure alpha prereleases" in changes  # nosec B101
+    assert "jsonbored/sure-aio-alpha:latest-alpha" in changes  # nosec B101
+    assert "commit SHA tags" in changes  # nosec B101
+    assert "beta/testing" in changes  # nosec B101
+    assert "separate app name" in changes  # nosec B101
+    assert "SURE_IMPORT_MAX_NDJSON_SIZE_MB" in changes  # nosec B101
+    assert "SURE_IMPORT_MAX_ROWS" in changes  # nosec B101
+    assert "WEBAUTHN_RP_ID" in changes  # nosec B101
+    assert "WEBAUTHN_ALLOWED_ORIGINS" in changes  # nosec B101


### PR DESCRIPTION
## Summary
- expand the Sure alpha XML changelog so users can see the actual alpha package differences
- harden tests for alpha import-limit behavior and upstream WebAuthn/passkey config exposure

## What changed
- documents alpha image/tag identity, beta/separate-install behavior, import limit knobs, and WebAuthn variables in `sure-aio-alpha.xml`
- adds alpha lane validation expectations to `docs/alpha-lane.md`
- expands XML tests for beta warning, stable isolation, import variable defaults/metadata, WebAuthn variable metadata, and changelog content
- expands Docker integration tests to boot isolated alpha containers for defaults, custom overrides, invalid fallback behavior, and WebAuthn parsing inside Rails

## Why
- the first alpha changelog only mentioned configurable import limits and did not clearly call out WebAuthn/passkey exposure or the separate beta package identity
- the first runtime smoke proved the happy path, but did not stress override/fallback behavior enough for this lane to serve as a dependable testing ground

## Validation
- `.venv-local/bin/python -m pytest -m 'not integration'`
- `.venv-local/bin/python -m pytest tests/integration/test_container_runtime.py -m integration`
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path ../sure-aio`
- `git diff --check`

## Notes
- image build/runtime logic is unchanged; this is docs, XML metadata, and validation hardening for the already-published alpha lane
