### PR TITLE
fix(release): keep stable sure image out of alpha metadata

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -272,6 +272,7 @@ components:
       - sure-aio-alpha.xml
     publish_paths:
       - README.md
+      - pyproject.toml
       - rootfs-alpha/**
       - patches/sure-alpha/**
       - docs/alpha-lane.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,6 @@ ARG S6_OVERLAY_AARCH64_SHA256=3fc0bae418a0e3811b3deeadfca9cc2f0869fb2f4787ab8a53
 ARG S6_OVERLAY_X86_64_SHA256=95081f11c56e5a351e9ccab4e70c2b1c3d7d056d82b72502b942762112c03d1c
 ARG TARGETARCH
 
-LABEL org.opencontainers.image.source="https://github.com/JSONbored/sure-aio" \
-      org.opencontainers.image.title="Sure AIO" \
-      org.opencontainers.image.description="Stable Unraid-first Sure AIO image"
-
 # hadolint ignore=DL3002
 USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -122,7 +122,6 @@ def test_alpha_overlay_is_documented_and_copied() -> None:
 
 def test_alpha_dockerfile_declares_revision_and_repo_metadata() -> None:
     alpha = (ROOT / "Dockerfile.alpha").read_text()
-    stable = (ROOT / "Dockerfile").read_text()
 
     assert "ARG AIO_REVISION=1" in alpha  # nosec B101
     assert (  # nosec B101
@@ -130,11 +129,6 @@ def test_alpha_dockerfile_declares_revision_and_repo_metadata() -> None:
         in alpha
     )
     assert 'org.opencontainers.image.title="Sure AIO Alpha"' in alpha  # nosec B101
-    assert (  # nosec B101
-        'org.opencontainers.image.source="https://github.com/JSONbored/sure-aio"'
-        in stable
-    )
-    assert "Sure AIO Alpha" not in stable  # nosec B101
 
 
 def test_alpha_release_history_is_separate_from_stable_changelog() -> None:


### PR DESCRIPTION
## Summary
- Remove the stable Dockerfile metadata-only edit from the alpha release-history change.
- Mark `pyproject.toml` as part of the alpha component publish/isolation surface.
- Keep alpha Dockerfile OCI metadata and release history intact.

## Why
- Stable `sure-aio` should stay out of alpha release planning unless we deliberately ship a stable AIO revision.

## Validation
- `.venv/bin/python -m pytest tests/test_alpha_lane_assets.py`
- `git diff --check`