### PR TITLE
docs(template): clarify sure alpha import wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An Unraid-first, single-container deployment of [Sure](https://github.com/we-pro
 
 This repo also carries `sure-aio-alpha`, a separate testing package managed by `aio-fleet` from the same source repo. It tracks upstream Sure alpha prereleases, publishes `jsonbored/sure-aio:latest-alpha`, and uses [sure-aio-alpha.xml](sure-aio-alpha.xml) with separate appdata paths and default host port `3001`.
 
-Alpha is intentionally not the stable package. It is where wrapper-only experiments live first, including the current configurable Sure import limits for larger TransmogriFi NDJSON testing. Alpha images publish under the same [Docker Hub](https://hub.docker.com/r/jsonbored/sure-aio) and [GHCR](https://github.com/users/JSONbored/packages/container/package/sure-aio) package as stable, but only through alpha tags and GitHub prereleases tagged as `sure-alpha/<version>`. See [docs/alpha-lane.md](docs/alpha-lane.md) before pointing it at important data.
+Alpha is intentionally not the stable package. It is where wrapper-only experiments live first, including the current configurable Sure import limits for larger NDJSON/import testing. Alpha images publish under the same [Docker Hub](https://hub.docker.com/r/jsonbored/sure-aio) and [GHCR](https://github.com/users/JSONbored/packages/container/package/sure-aio) package as stable, but only through alpha tags and GitHub prereleases tagged as `sure-alpha/<version>`. See [docs/alpha-lane.md](docs/alpha-lane.md) before pointing it at important data.
 
 ## Beginner Install
 

--- a/docs/alpha-lane.md
+++ b/docs/alpha-lane.md
@@ -24,7 +24,7 @@ The alpha XML changelog must call out exposed upstream alpha controls separately
 - Status: active alpha-only overlay.
 - Overlay: `rootfs-alpha/rails/config/initializers/sure_aio_alpha_import_limits.rb`.
 - Defaults: `SURE_IMPORT_MAX_NDJSON_SIZE_MB=250`, `SURE_IMPORT_MAX_ROWS=1000000`.
-- Why: TransmogriFi local testing needs larger Sure NDJSON imports than upstream's current `10MB` upload limit and `100000` row/import limit.
+- Why: local alpha testing needs larger Sure NDJSON imports than upstream's current `10MB` upload limit and `100000` row/import limit.
 - Upstream issue/PR: none yet.
 - Promotion/removal path: keep alpha-only until the behavior is accepted upstream or we deliberately decide the raised/configurable limits are safe for stable Unraid users.
 

--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -16,7 +16,7 @@ This template is meant for testing and local validation, not primary household f
 &#xD;
 [b]Alpha customizations[/b]&#xD;
 - Raises Sure NDJSON import defaults to [code]250MB[/code] and [code]1,000,000[/code] rows.&#xD;
-- Exposes [code]SURE_IMPORT_MAX_NDJSON_SIZE_MB[/code] and [code]SURE_IMPORT_MAX_ROWS[/code] for testing larger TransmogriFi imports.&#xD;
+- Exposes [code]SURE_IMPORT_MAX_NDJSON_SIZE_MB[/code] and [code]SURE_IMPORT_MAX_ROWS[/code] for larger alpha import testing.&#xD;
 - Uses a separate alpha tag namespace, Web UI port, and appdata root from stable.&#xD;
 &#xD;
 [b]Quick Install[/b]&#xD;


### PR DESCRIPTION
## Summary
- Updates the Sure alpha template and docs wording for import-limit testing.

## Validation
- `.venv-local/bin/python -m pytest tests/test_alpha_lane_assets.py`
- `git diff --check`

## Notes
- Stable template behavior is unchanged.