### PR TITLE
build(tags): bump sure alpha aio revision

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -6,6 +6,14 @@ are upstreamed or promoted to stable. Alpha uses the shared `jsonbored/sure-aio`
 image repo with alpha-only tags; the old `jsonbored/sure-aio-alpha` image repo
 is retired.
 
+## 0.7.1-alpha.7-aio.3 - 2026-05-18
+
+### Build
+
+- Reissue the current Sure alpha package from the latest main commit after the immutable `0.7.1-alpha.7-aio.2` prerelease was already published from an older commit.
+- Keep runtime behavior aligned with `0.7.1-alpha.7-aio.2`: upstream Sure alpha 0.7.1-alpha.7, the alpha-only import-limit overlay, shared `jsonbored/sure-aio:*alpha*` tags, and alpha WebAuthn template controls.
+- Keep stable `sure-aio` unchanged; this release history applies only to `sure-aio-alpha`.
+
 ## 0.7.1-alpha.7-aio.2 - 2026-05-18
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you care about the instance, back up all three paths.
 - wrapper releases follow the upstream version plus an AIO revision, such as `v0.6.9-aio.1`
 - Stable upstream monitoring, release preparation, registry publishing, and catalog sync are owned by `aio-fleet` from `.aio-fleet.yml`.
 - `main` publishes `latest`, the exact upstream version tag, an explicit AIO packaging line tag, and `sha-<commit>`
-- Alpha publishes to the shared `jsonbored/sure-aio` image repo with `latest-alpha`, the upstream alpha version, an explicit AIO revision tag such as `0.7.1-alpha.7-aio.2`, and `sha-alpha-<commit>`.
+- Alpha publishes to the shared `jsonbored/sure-aio` image repo with `latest-alpha`, the upstream alpha version, an explicit AIO revision tag such as `0.7.1-alpha.7-aio.3`, and `sha-alpha-<commit>`.
 - Alpha release history lives in [CHANGELOG.alpha.md](CHANGELOG.alpha.md) and GitHub prereleases under the `sure-alpha/` tag namespace so stable release history stays clean.
 - Changelog generation and XML `<Changes>` sync are run centrally by `aio-fleet` during release preparation.
 

--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -32,7 +32,7 @@ This template is meant for testing and local validation, not primary household f
   <Changes>### 2026-05-17&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
 - Add Sure AIO Alpha testing lane tracking upstream Sure alpha prereleases.&#xD;
-- Publish alpha images under the shared [code]jsonbored/sure-aio[/code] image repo as [code]latest-alpha[/code], upstream alpha version tags, alpha AIO revision tags such as [code]0.7.1-alpha.7-aio.2[/code], and [code]sha-alpha-&lt;commit&gt;[/code] tags.&#xD;
+- Publish alpha images under the shared [code]jsonbored/sure-aio[/code] image repo as [code]latest-alpha[/code], upstream alpha version tags, alpha AIO revision tags such as [code]0.7.1-alpha.7-aio.3[/code], and [code]sha-alpha-&lt;commit&gt;[/code] tags.&#xD;
 - Mark the template as beta/testing with a separate app name, default Web UI port, and appdata root from stable [code]sure-aio[/code].&#xD;
 - Add alpha-only import limit controls: [code]SURE_IMPORT_MAX_NDJSON_SIZE_MB[/code] defaults to [code]250[/code], and [code]SURE_IMPORT_MAX_ROWS[/code] defaults to [code]1000000[/code].&#xD;
 - Expose upstream alpha passkey/WebAuthn controls: [code]WEBAUTHN_RP_ID[/code] and [code]WEBAUTHN_ALLOWED_ORIGINS[/code].</Changes>

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -134,9 +134,9 @@ def test_alpha_release_history_is_separate_from_stable_changelog() -> None:
     alpha_changelog = (ROOT / "CHANGELOG.alpha.md").read_text()
     stable_changelog = (ROOT / "CHANGELOG.md").read_text()
 
-    assert "0.7.1-alpha.7-aio.2" in alpha_changelog  # nosec B101
+    assert "0.7.1-alpha.7-aio.3" in alpha_changelog  # nosec B101
     assert "docs/alpha-lane.md" in alpha_changelog  # nosec B101
-    assert "0.7.1-alpha.7-aio.2" not in stable_changelog  # nosec B101
+    assert "0.7.1-alpha.7-aio.3" not in stable_changelog  # nosec B101
 
 
 def test_alpha_changelog_documents_runtime_differences() -> None:
@@ -146,7 +146,7 @@ def test_alpha_changelog_documents_runtime_differences() -> None:
     assert "upstream Sure alpha prereleases" in changes  # nosec B101
     assert "jsonbored/sure-aio" in changes  # nosec B101
     assert "latest-alpha" in changes  # nosec B101
-    assert "0.7.1-alpha.7-aio.2" in changes  # nosec B101
+    assert "0.7.1-alpha.7-aio.3" in changes  # nosec B101
     assert "sha-alpha-<commit>" in changes  # nosec B101
     assert "beta/testing" in changes  # nosec B101
     assert "separate app name" in changes  # nosec B101


### PR DESCRIPTION
## Summary
- Bump the Sure alpha AIO revision to avoid retargeting the immutable `sure-alpha/0.7.1-alpha.7-aio.2` prerelease.

## What changed
- Add `0.7.1-alpha.7-aio.3` to the alpha changelog.
- Update alpha template and README release-tag references.
- Update alpha lane asset tests for the new current alpha AIO revision.

## Why
- The existing alpha prerelease points at an older commit and should not be retargeted. A new AIO revision gives the current commit its own publish target.

## Validation
- `uv run --with pytest python -m pytest tests/test_alpha_lane_assets.py`
- `git diff --check`

## Notes
- Stable `sure-aio` release history remains unchanged.
