### PR TITLE
docs(tags): align sure alpha package docs

### DIFF
--- a/docs/alpha-lane.md
+++ b/docs/alpha-lane.md
@@ -1,10 +1,10 @@
 # Sure AIO Alpha Lane
 
-`sure-aio-alpha` is the testing lane for Sure prereleases and small wrapper-only experiments. It is separately installable from stable `sure-aio`, publishes to the shared `jsonbored/sure-aio` image repo with alpha-only tags, and uses separate Unraid appdata paths.
+`sure-aio-alpha` is the testing lane for Sure prereleases and small wrapper-only experiments. It is separately installable from stable `sure-aio`, publishes to the dedicated `jsonbored/sure-aio-alpha` Docker Hub and GHCR packages, and uses separate Unraid appdata paths.
 
 Alpha updates track upstream `we-promise/sure` alpha prereleases through `aio-fleet`. Routine alpha bumps publish images, update the alpha template, and create/update GitHub prereleases under the `sure-alpha/` tag namespace without creating stable Sure AIO release debt.
 
-Release history for this lane lives in `CHANGELOG.alpha.md`. Image tags include `latest-alpha`, the upstream alpha version, the alpha AIO revision tag, and `sha-alpha-<commit>`.
+Release history for this lane lives in `CHANGELOG.alpha.md`. Image tags are intentionally limited to `latest-alpha` and the explicit alpha AIO revision tag, such as `0.7.1-alpha.7-aio.5`.
 
 ## Upstream Alpha Template Surface
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -20,10 +20,11 @@ Every central `aio-fleet` publish for `main` publishes:
 
 Release commits also publish the immutable packaging line tag, for example `v0.6.9-aio-v3` derived from `v0.6.9-aio.3`. Ordinary `main` pushes do not overwrite that release tag.
 
-The alpha lane shares the same `jsonbored/sure-aio` image repo, but uses only
-alpha tags: `latest-alpha`, the upstream alpha version, the alpha AIO revision
-tag, and `sha-alpha-<commit>`. Alpha prereleases use the `sure-alpha/` Git tag
-namespace and do not move stable `latest`.
+The alpha lane publishes to dedicated Docker Hub and GHCR packages named
+`jsonbored/sure-aio-alpha`. It intentionally publishes only `latest-alpha` and
+the explicit alpha AIO revision tag, such as `0.7.1-alpha.7-aio.5`. Alpha
+prereleases use the `sure-alpha/` Git tag namespace and do not move stable
+`latest`.
 
 ## Release flow
 

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -155,3 +155,21 @@ def test_alpha_changelog_documents_runtime_differences() -> None:
     assert "SURE_IMPORT_MAX_ROWS" in changes  # nosec B101
     assert "WEBAUTHN_RP_ID" in changes  # nosec B101
     assert "WEBAUTHN_ALLOWED_ORIGINS" in changes  # nosec B101
+
+
+def test_alpha_docs_use_dedicated_package_and_trimmed_tags() -> None:
+    docs = "\n".join(
+        [
+            (ROOT / "README.md").read_text(),
+            (ROOT / "docs/alpha-lane.md").read_text(),
+            (ROOT / "docs/releases.md").read_text(),
+        ]
+    )
+
+    assert "jsonbored/sure-aio-alpha" in docs  # nosec B101
+    assert "latest-alpha" in docs  # nosec B101
+    assert "0.7.1-alpha.7-aio.5" in docs  # nosec B101
+    assert "publishes to the shared `jsonbored/sure-aio`" not in docs  # nosec B101
+    assert "shares the same `jsonbored/sure-aio` image repo" not in docs  # nosec B101
+    assert "sha-alpha-<commit>" not in docs  # nosec B101
+    assert "the upstream alpha version tag" not in docs  # nosec B101


### PR DESCRIPTION
## Summary
- Update alpha lane docs to describe the dedicated `sure-aio-alpha` Docker Hub and GHCR packages.
- Document the trimmed alpha tag set: `latest-alpha` plus the explicit alpha AIO revision tag.
- Add a regression test so docs do not drift back to the old shared-image scheme.

## Validation
- `python -m pytest tests/test_alpha_lane_assets.py`
- `black --target-version py312 --check tests/test_alpha_lane_assets.py`
- `git diff --check`