### PR TITLE
chore(sync): bump sure alpha to 0.7.1-alpha.9

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -6,6 +6,19 @@ are upstreamed or promoted to stable. Alpha uses the dedicated
 `jsonbored/sure-aio-alpha` image repo so testing tags stay out of the stable
 `jsonbored/sure-aio` package.
 
+## 0.7.1-alpha.9-aio.1 - 2026-05-19
+
+### Build
+- Track upstream Sure Alpha 0.7.1-alpha.9.
+- Publish Docker Hub and GHCR tags with the configured component revision tag.
+
+### Component Customizations
+- Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.
+- Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.
+- Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.
+- Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.
+- Do not add dirty-target taxonomy merge as a Unraid template or environment control.
+- Keep alpha passkey/WebAuthn template controls separate from stable.
 ## 0.7.1-alpha.7-aio.8 - 2026-05-19
 
 ### Alpha Customizations

--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -9,16 +9,19 @@ are upstreamed or promoted to stable. Alpha uses the dedicated
 ## 0.7.1-alpha.9-aio.1 - 2026-05-19
 
 ### Build
+
 - Track upstream Sure Alpha 0.7.1-alpha.9.
 - Publish Docker Hub and GHCR tags with the configured component revision tag.
 
 ### Component Customizations
+
 - Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.
 - Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.
 - Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.
 - Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.
 - Do not add dirty-target taxonomy merge as a Unraid template or environment control.
 - Keep alpha passkey/WebAuthn template controls separate from stable.
+
 ## 0.7.1-alpha.7-aio.8 - 2026-05-19
 
 ### Alpha Customizations

--- a/Dockerfile.alpha
+++ b/Dockerfile.alpha
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 # checkov:skip=CKV_DOCKER_8: s6-overlay entrypoint must start as root so init scripts can prepare filesystem state before dropping privileges
 
-ARG UPSTREAM_VERSION=0.7.1-alpha.7
-ARG UPSTREAM_IMAGE_DIGEST=sha256:42eeb624c90d27f78124cb8a5e247715297f8a5825bcab69d51327ab95b57958
-ARG AIO_REVISION=8
+ARG UPSTREAM_VERSION=0.7.1-alpha.9
+ARG UPSTREAM_IMAGE_DIGEST=sha256:69e635f6aae42f17b8f00a8002dd36887a259ca3c7c2c99152635798d279575d
+ARG AIO_REVISION=1
 ARG PGVECTOR_VERSION=0.8.2
 FROM ghcr.io/we-promise/sure:${UPSTREAM_VERSION}@${UPSTREAM_IMAGE_DIGEST}
 

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -225,7 +225,7 @@ def test_alpha_overlay_is_documented_and_copied() -> None:
 def test_alpha_dockerfile_declares_revision_and_repo_metadata() -> None:
     alpha = (ROOT / "Dockerfile.alpha").read_text()
 
-    assert "ARG AIO_REVISION=8" in alpha  # nosec B101
+    assert "ARG AIO_REVISION=1" in alpha  # nosec B101
     assert (  # nosec B101
         'org.opencontainers.image.source="https://github.com/JSONbored/sure-aio"'
         in alpha
@@ -237,9 +237,9 @@ def test_alpha_release_history_is_separate_from_stable_changelog() -> None:
     alpha_changelog = (ROOT / "CHANGELOG.alpha.md").read_text()
     stable_changelog = (ROOT / "CHANGELOG.md").read_text()
 
-    assert "0.7.1-alpha.7-aio.8" in alpha_changelog  # nosec B101
+    assert "0.7.1-alpha.9-aio.1" in alpha_changelog  # nosec B101
     assert "docs/alpha-lane.md" in alpha_changelog  # nosec B101
-    assert "0.7.1-alpha.7-aio.8" not in stable_changelog  # nosec B101
+    assert "0.7.1-alpha.9-aio.1" not in stable_changelog  # nosec B101
 
 
 def test_alpha_changelog_documents_runtime_differences() -> None:


### PR DESCRIPTION
## Summary
- Updates upstream pins for `sure-aio`.

## What changed
- Sure Alpha: 0.7.1-alpha.7 -> 0.7.1-alpha.9 plus image digest refresh
- Release notes: https://github.com/we-promise/sure/releases
- Source repo paths reviewed/generated:
  - `CHANGELOG.alpha.md`
  - `Dockerfile.alpha`


## Why
- Keeps the AIO wrapper aligned with upstream while preserving human review.
- Source repo changes are validated here first; catalog sync follows the validated source repo and never starts in `awesome-unraid`.

## Validation
- Generated by `aio-fleet upstream monitor`; central checks should run on this PR.
- The generated commit must be verified/signed before branch protection allows merge.

## Safety assessment
- Safety: `blocked` (0.10 confidence)
- Config delta: none
- Template impact: manifest-targets-present
- Runtime smoke: configured-not-seen
- Next action: unexpected upstream PR file(s): CHANGELOG.alpha.md
- Blocking finding: unexpected upstream PR file(s): CHANGELOG.alpha.md
- Review warning: release notes inspection pending on dashboard refresh
- Review warning: runtime/integration tests are configured but no PR runtime check was found
- Dashboard safety state is authoritative after this PR and its checks are visible to `aio-fleet`.