### PR TITLE
chore(release): 0.7.0-hotfix.3-aio.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.0-hotfix.3-aio.2 - 2026-05-19
+
+### Fixes
+
+- Harden Sure runtime, template secret masking, and release paths.
+- Derive external assistant session keys when operators leave the shared key blank.
+- Tighten first-boot database readiness so Rails waits for authenticated PostgreSQL access.
+
 ## 0.7.0-hotfix.3-aio.1 - 2026-05-17
 
 ### Maintenance

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,9 +31,11 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-05-17&#xD;
+  <Changes>### 2026-05-19&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Bump sure to 0.7.0-hotfix.3 (#95)</Changes>
+- Harden Sure runtime, template secret masking, and release paths.&#xD;
+- Derive external assistant session keys when operators leave the shared key blank.&#xD;
+- Tighten first-boot database readiness so Rails waits for authenticated PostgreSQL access.</Changes>
   <Category>Productivity: Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare `0.7.0-hotfix.3-aio.2`
- update stable source template `<Changes>` from the release notes

## Why
This publishes the merged Sure stable runtime/template hardening as a formal stable package revision.

## Validation
- `python -m pytest tests/test_alpha_lane_assets.py`
- `python -m aio_fleet validate-repo --repo sure-aio`
- `git diff --check`
