### PR TITLE
chore(sync): bump sure alpha to 0.7.1-alpha.10

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -6,6 +6,22 @@ are upstreamed or promoted to stable. Alpha uses the dedicated
 `jsonbored/sure-aio-alpha` image repo so testing tags stay out of the stable
 `jsonbored/sure-aio` package.
 
+## 0.7.1-alpha.10-aio.1 - 2026-05-22
+
+### Build
+
+- Track upstream Sure Alpha 0.7.1-alpha.10.
+- Publish Docker Hub and GHCR tags with the configured component revision tag.
+
+### Component Customizations
+
+- Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.
+- Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.
+- Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.
+- Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.
+- Do not add dirty-target taxonomy merge as a Unraid template or environment control.
+- Keep alpha passkey/WebAuthn template controls separate from stable.
+
 ## 0.7.1-alpha.9-aio.2 - 2026-05-19
 
 ### Fixes

--- a/Dockerfile.alpha
+++ b/Dockerfile.alpha
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 # checkov:skip=CKV_DOCKER_8: s6-overlay entrypoint must start as root so init scripts can prepare filesystem state before dropping privileges
 
-ARG UPSTREAM_VERSION=0.7.1-alpha.9
-ARG UPSTREAM_IMAGE_DIGEST=sha256:69e635f6aae42f17b8f00a8002dd36887a259ca3c7c2c99152635798d279575d
-ARG AIO_REVISION=2
+ARG UPSTREAM_VERSION=0.7.1-alpha.10
+ARG UPSTREAM_IMAGE_DIGEST=sha256:aa8cbb5c0bdc0f0770d0dbe42947c7e54b673089c30896bebd3f143678ba871f
+ARG AIO_REVISION=1
 ARG PGVECTOR_VERSION=0.8.2
 FROM ghcr.io/we-promise/sure:${UPSTREAM_VERSION}@${UPSTREAM_IMAGE_DIGEST}
 

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -293,7 +293,7 @@ def test_alpha_overlay_is_documented_and_copied() -> None:
 def test_alpha_dockerfile_declares_revision_and_repo_metadata() -> None:
     alpha = (ROOT / "Dockerfile.alpha").read_text()
 
-    assert "ARG AIO_REVISION=2" in alpha  # nosec B101
+    assert "ARG AIO_REVISION=1" in alpha  # nosec B101
     assert (  # nosec B101
         'org.opencontainers.image.source="https://github.com/JSONbored/sure-aio"'
         in alpha
@@ -305,7 +305,7 @@ def test_alpha_release_history_is_separate_from_stable_changelog() -> None:
     alpha_changelog = (ROOT / "CHANGELOG.alpha.md").read_text()
     stable_changelog = (ROOT / "CHANGELOG.md").read_text()
 
-    assert "0.7.1-alpha.9-aio.1" in alpha_changelog  # nosec B101
+    assert "0.7.1-alpha.10-aio.1" in alpha_changelog  # nosec B101
     assert "docs/alpha-lane.md" in alpha_changelog  # nosec B101
     assert "0.7.1-alpha.9-aio.1" not in stable_changelog  # nosec B101
 


### PR DESCRIPTION
## Summary
- Bump the Sure alpha image lane to upstream `0.7.1-alpha.10`.
- Reset the alpha AIO revision to `1` for the new upstream prerelease.
- Update the alpha asset regression test for the new revision and changelog entry.

## Validation
- `uv run --with pytest pytest -q tests/test_alpha_lane_assets.py`
- `git diff --check`

## Notes
- Stable Sure remains pinned to `0.7.0-hotfix.3` because the newer upstream versions are GitHub prereleases.
