### PR TITLE
chore(release): 0.7.0-hotfix.3-aio.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.0-hotfix.3-aio.3 - 2026-05-26
+
+### Documentation
+
+- Normalize CA metadata
+
+### Maintenance
+
+- Reconcile app manifest
+
+- Bump sure alpha to 0.7.1-alpha.10
+
+- Bump sure alpha to 0.7.1-alpha.11
+
 ## 0.7.0-hotfix.3-aio.2 - 2026-05-19
 
 ### Fixes

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,11 +31,12 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-05-19&#xD;
+  <Changes>### 2026-05-26&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Harden Sure runtime, template secret masking, and release paths.&#xD;
-- Derive external assistant session keys when operators leave the shared key blank.&#xD;
-- Tighten first-boot database readiness so Rails waits for authenticated PostgreSQL access.</Changes>
+- Normalize CA metadata&#xD;
+- Reconcile app manifest&#xD;
+- Bump sure alpha to 0.7.1-alpha.10&#xD;
+- Bump sure alpha to 0.7.1-alpha.11</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Cut the 0.7.0-hotfix.3-aio.3 release metadata.
- Update CHANGELOG.md and sure-aio.xml <Changes> for the release.

## Validation
- `git diff --check`
- XML parse check for `sure-aio.xml`
- `uv run --with pytest python -m pytest -q tests/test_alpha_lane_assets.py`
- commit hook: Trunk and fleet policy checks passed
