### PR TITLE
chore(release): 0.7.0-hotfix.3-aio.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.0-hotfix.3-aio.4 - 2026-05-31
+
+### Fixes
+
+- Preserve Rails origin checks behind reverse proxies
+
 ## 0.7.0-hotfix.3-aio.3 - 2026-05-26
 
 ### Documentation

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,12 +31,9 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-05-26&#xD;
+  <Changes>### 2026-05-31&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Normalize CA metadata&#xD;
-- Reconcile app manifest&#xD;
-- Bump sure alpha to 0.7.1-alpha.10&#xD;
-- Bump sure alpha to 0.7.1-alpha.11</Changes>
+- Preserve Rails origin checks behind reverse proxies</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Bumps stable Sure-AIO release metadata for the merged reverse-proxy referrer policy fix.

## What changed
- Adds the 0.7.0-hotfix.3-aio.4 changelog entry.
- Updates stable Community Apps XML Changes metadata.

## Why
- The source fix and SHA image are published, but normal stable users need release metadata bumped before rolling and version tags can move through the release path.

## Validation
- `git diff --check`
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path ../sure-aio`
- `python -m aio_fleet validate-template-common --repo sure-aio --repo-path ../sure-aio`
- `python -m aio_fleet validate-derived --repo-path ../sure-aio`
- `python -m pytest tests/test_alpha_lane_assets.py`