### PR TITLE
chore(release): 0.7.1-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.1-aio.1 - 2026-05-31
+
+### Fixes
+
+- Preserve Rails origin checks behind reverse proxies
+
+- Add null-origin support for Sure 0.7.1
+
 ## 0.7.0-hotfix.3-aio.4 - 2026-05-31
 
 ### Fixes

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -33,7 +33,8 @@
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
   <Changes>### 2026-05-31&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Preserve Rails origin checks behind reverse proxies</Changes>
+- Preserve Rails origin checks behind reverse proxies&#xD;
+- Add null-origin support for Sure 0.7.1</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- Prepares the stable Sure-AIO `0.7.1-aio.1` release metadata.

## What changed
- Adds the `0.7.1-aio.1` changelog entry.
- Updates the stable Unraid XML `<Changes>` metadata from the changelog.

## Why
- The 0.7.1 source bump and proxy compatibility fix are merged on `main`; this release commit is required before the stable version tag, GitHub Release, and rolling image tags can be published normally.

## Validation
- `git diff --check`
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path ../sure-aio`
- `python -m aio_fleet validate-template-common --repo sure-aio --repo-path ../sure-aio`
- `python -m pytest tests/test_alpha_lane_assets.py`

## Notes
- Catalog sync should follow after this source release metadata is merged.
