### PR TITLE
fix(proxy): allow service worker behind reverse proxies

### DIFF
--- a/rootfs/rails/config/initializers/sure_aio_pwa_service_worker_forgery.rb
+++ b/rootfs/rails/config/initializers/sure_aio_pwa_service_worker_forgery.rb
@@ -1,0 +1,20 @@
+# The PWA service worker is a public GET asset served by an upstream Rails
+# controller as JavaScript. Rails' same-origin JavaScript response guard
+# otherwise treats normal browser service-worker registration as a protected
+# cross-origin script response and logs ActionController::InvalidCrossOriginRequest.
+module SureAioPwaServiceWorkerForgeryGuard
+  private
+
+  def verify_same_origin_request
+    return if action_name == "service_worker"
+
+    super
+  end
+end
+
+Rails.application.config.to_prepare do
+  controller = "PwaController".safe_constantize
+  next unless controller
+
+  controller.prepend SureAioPwaServiceWorkerForgeryGuard
+end

--- a/tests/integration/test_container_runtime.py
+++ b/tests/integration/test_container_runtime.py
@@ -144,6 +144,31 @@ def post_login_with_null_origin(host_port: int, cookie_path: str, token: str):
     )
 
 
+def get_service_worker(host_port: int):
+    return run_command(
+        [
+            "curl",
+            "-sS",
+            "-D",
+            "-",
+            "-o",
+            "-",
+            "-H",
+            "Host: sure.domain.com",
+            "-H",
+            "X-Forwarded-Host: sure.domain.com",
+            "-H",
+            "X-Forwarded-Port: 443",
+            "-H",
+            "X-Forwarded-Proto: https",
+            "-H",
+            "X-Forwarded-Ssl: on",
+            f"http://127.0.0.1:{host_port}/service-worker",
+        ],
+        check=False,
+    )
+
+
 def assert_alpha_import_and_webauthn_config(
     container_name: str,
     expected: str,
@@ -422,6 +447,42 @@ def test_proxy_null_origin_escape_hatch_keeps_token_csrf_validation(
                 "The change you wanted was rejected" not in result.stdout
             )  # nosec B101
             assert "InvalidAuthenticityToken" not in logs(name)  # nosec B101
+
+
+def test_proxy_service_worker_does_not_trigger_cross_origin_js_guard(
+    build_image,
+) -> None:
+    proxy_env = {
+        "APP_DOMAIN": "sure.domain.com",
+        "APP_URL": "https://sure.domain.com",
+        "RAILS_ASSUME_SSL": "true",
+        "RAILS_FORCE_SSL": "false",
+        "SURE_CSRF_ORIGIN_CHECK": "false",
+        "SURE_REFERRER_POLICY": "strict-origin-when-cross-origin",
+    }
+
+    with (
+        docker_volume("sure-aio-service-worker-storage") as storage_volume,
+        docker_volume("sure-aio-service-worker-pg") as pgdata_volume,
+        docker_volume("sure-aio-service-worker-redis") as redis_volume,
+    ):
+        with container(
+            storage_volume,
+            pgdata_volume,
+            redis_volume,
+            extra_env=proxy_env,
+        ) as (name, host_port):
+            wait_for_http(name, host_port)
+            result = get_service_worker(host_port)
+
+            assert "HTTP/1.1 200" in result.stdout  # nosec B101
+            assert (
+                "content-type: application/javascript" in result.stdout.lower()
+            )  # nosec B101
+            assert "CACHE_VERSION" in result.stdout  # nosec B101
+            assert "ActionController::InvalidCrossOriginRequest" not in logs(
+                name
+            )  # nosec B101
 
 
 def test_alpha_image_boots_with_version_import_limits_and_webauthn_env(

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -180,6 +180,9 @@ def test_shared_runtime_waits_for_final_postgres_and_omits_init_db() -> None:
     csrf_origin_check = (
         ROOT / "rootfs/rails/config/initializers/sure_aio_csrf_origin_check.rb"
     ).read_text()
+    service_worker_forgery = (
+        ROOT / "rootfs/rails/config/initializers/sure_aio_pwa_service_worker_forgery.rb"
+    ).read_text()
 
     assert (  # nosec B101
         ROOT / "rootfs/etc/s6-overlay/s6-rc.d/web/dependencies.d/postgres"
@@ -204,6 +207,9 @@ def test_shared_runtime_waits_for_final_postgres_and_omits_init_db() -> None:
     )  # nosec B101
     assert "forgery_protection_origin_check = false" in csrf_origin_check  # nosec B101
     assert "Rails CSRF token" in csrf_origin_check  # nosec B101
+    assert "PwaController" in service_worker_forgery  # nosec B101
+    assert "verify_same_origin_request" in service_worker_forgery  # nosec B101
+    assert 'action_name == "service_worker"' in service_worker_forgery  # nosec B101
 
 
 def test_alpha_template_exposes_upstream_alpha_webauthn_controls() -> None:


### PR DESCRIPTION
## Summary
- Allows Sure's public PWA service-worker endpoint to respond behind reverse proxies without triggering Rails' same-origin JavaScript response guard.
- Adds proxy regression coverage for forwarded HTTPS headers and `/service-worker`.

## What changed
- Adds a Rails initializer that bypasses `verify_same_origin_request` only for `PwaController#service_worker` while leaving request forgery verification in place.
- Adds a Docker integration test that requests `/service-worker` through forwarded HTTPS headers and asserts no `ActionController::InvalidCrossOriginRequest` is logged.
- Extends static asset coverage so the initializer stays packaged in the AIO image.

## Why
- Issue #120 showed `ActionController::InvalidCrossOriginRequest` after the null-origin login workaround allowed login behind Cloudflare/Traefik.
- `/service-worker` is a public GET JavaScript asset registered by the browser, not a state-changing form endpoint, so this keeps the compatibility fix narrow.

## Validation
- `python -m pytest tests/test_alpha_lane_assets.py` (13 passed)
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path .`
- `python -m pytest tests/integration/test_container_runtime.py::test_proxy_service_worker_does_not_trigger_cross_origin_js_guard -m integration` (1 passed)
- `AIO_PYTEST_USE_PREBUILT_IMAGE=true python -m pytest tests/integration/test_container_runtime.py::test_proxy_null_origin_escape_hatch_keeps_token_csrf_validation tests/integration/test_container_runtime.py::test_proxy_service_worker_does_not_trigger_cross_origin_js_guard -m integration` (2 passed)
- `docker run --rm --entrypoint ruby sure-aio:pytest -c /rails/config/initializers/sure_aio_pwa_service_worker_forgery.rb` (Syntax OK)
- `git diff --check`

## Notes
- Refs #120.
- Local reproduction before this change confirmed `/service-worker` could return HTTP 422 with forwarded HTTPS headers; the regression now expects HTTP 200 and JavaScript content.
