### PR TITLE
chore(release): 0.7.1-aio.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.1-aio.2 - 2026-06-01
+
+### Fixes
+
+- Allow service worker behind reverse proxies
+
 ## 0.7.1-aio.1 - 2026-05-31
 
 ### Fixes

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,10 +31,9 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-05-31&#xD;
+  <Changes>### 2026-06-01&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Preserve Rails origin checks behind reverse proxies&#xD;
-- Add null-origin support for Sure 0.7.1</Changes>
+- Allow service worker behind reverse proxies</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
## Summary
- prepare the stable Sure AIO `0.7.1-aio.2` release
- move the user-facing registry tag set onto the merged reverse-proxy service-worker fix

## What changed
- adds the `0.7.1-aio.2` changelog entry
- updates the stable Unraid XML `<Changes>` text for the service-worker reverse-proxy fix

## Why
- the service-worker fix merged after `0.7.1-aio.1`, so the current `latest` image still does not include it
- a new AIO revision is required before `latest`, `0.7.1`, and `0.7.1-aio.2` can point at the fixed image

## Validation
- `python -m aio_fleet release status --repo sure-aio --repo-path . --format json`
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path .`
- `python -m pytest tests/test_alpha_lane_assets.py`
- `AIO_PYTEST_USE_PREBUILT_IMAGE=true python -m pytest tests/integration/test_container_runtime.py::test_proxy_null_origin_escape_hatch_keeps_token_csrf_validation tests/integration/test_container_runtime.py::test_proxy_service_worker_does_not_trigger_cross_origin_js_guard -m integration`
- `git diff --check`

## Notes
- The integration regression was run against the fixed published SHA image retagged for the local test harness.
- The current public `latest` image was also checked and still returns 422 for the service-worker path, which is why this release PR should land before telling users the normal update path is fixed.
