### PR TITLE
chore(release): 0.7.1-alpha.11-aio.2

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -6,6 +6,23 @@ are upstreamed or promoted to stable. Alpha uses the dedicated
 `jsonbored/sure-aio-alpha` image repo so testing tags stay out of the stable
 `jsonbored/sure-aio` package.
 
+## 0.7.1-alpha.11-aio.2 - 2026-06-01
+
+### Fixes
+
+- Preserve Rails origin checks behind reverse proxies.
+- Add null-origin compatibility for Sure 0.7.1 alpha proxy login paths.
+- Allow the browser service worker behind reverse proxies without triggering Rails cross-origin JavaScript protection.
+
+### Component Customizations
+
+- Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.
+- Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.
+- Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.
+- Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.
+- Do not add dirty-target taxonomy merge as a Unraid template or environment control.
+- Keep alpha passkey/WebAuthn template controls separate from stable.
+
 ## 0.7.1-alpha.11-aio.1 - 2026-05-25
 
 ### Build

--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -32,12 +32,11 @@ This template is meant for testing and local validation, not primary household f
 - [code]/mnt/user/appdata/sure-aio-alpha/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio-alpha/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio-alpha/redis[/code]</Overview>
-  <Changes>### 2026-05-19&#xD;
+  <Changes>### 2026-06-01&#xD;
 - Generated from CHANGELOG.alpha.md during release preparation. Do not edit manually.&#xD;
-- Harden Sure runtime, alpha import preflight, template secret masking, and release paths.&#xD;
-- Enforce capped alpha import limits and structured malformed Account preflight errors.&#xD;
-- Derive external assistant session keys when operators leave the shared key blank.&#xD;
-- Tighten first-boot database readiness so Rails waits for authenticated PostgreSQL access.</Changes>
+- Preserve Rails origin checks behind reverse proxies.&#xD;
+- Add null-origin compatibility for Sure 0.7.1 alpha proxy login paths.&#xD;
+- Allow the browser service worker behind reverse proxies without triggering Rails cross-origin JavaScript protection.</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <Beta>True</Beta>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -398,9 +398,9 @@ def test_alpha_changelog_documents_runtime_differences() -> None:
     assert "SURE_IMPORT_MAX_ROWS" in overview  # nosec B101
     assert "strict SureImport preflight" in overview  # nosec B101
     assert "admin reset UI/task" in overview  # nosec B101
-    assert "Harden Sure runtime" in changes  # nosec B101
-    assert "malformed Account preflight errors" in changes  # nosec B101
-    assert "authenticated PostgreSQL access" in changes  # nosec B101
+    assert "Preserve Rails origin checks" in changes  # nosec B101
+    assert "null-origin compatibility" in changes  # nosec B101
+    assert "browser service worker" in changes  # nosec B101
 
 
 def test_alpha_docs_use_dedicated_package_and_trimmed_tags() -> None:


### PR DESCRIPTION
## Summary
- release the Sure alpha lane with the reverse-proxy CSRF and service-worker fixes already merged on main
- refresh the alpha changelog and Community Apps-facing `<Changes>` text for `0.7.1-alpha.11-aio.2`

## What changed
- added the `0.7.1-alpha.11-aio.2` alpha release entry
- updated `sure-aio-alpha.xml` release notes for the proxy/runtime fix
- updated alpha asset assertions for the new release notes

## Why
- the published alpha image still carries the old proxy behavior even though main contains the fix
- alpha users need the same Traefik/Cloudflare compatibility path as stable while keeping alpha-only import and WebAuthn behavior intact

## Validation
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path .`
- `python -m pytest tests/test_alpha_lane_assets.py`
- `docker build --platform linux/amd64 -f Dockerfile.alpha -t sure-aio-alpha:pytest -t sure-aio:pytest .`
- `AIO_PYTEST_USE_PREBUILT_IMAGE=true AIO_ALPHA_PYTEST_USE_PREBUILT_IMAGE=true python -m pytest tests/integration/test_container_runtime.py::test_proxy_null_origin_escape_hatch_keeps_token_csrf_validation tests/integration/test_container_runtime.py::test_proxy_service_worker_does_not_trigger_cross_origin_js_guard tests/integration/test_container_runtime.py::test_alpha_image_boots_with_version_import_limits_and_webauthn_env tests/integration/test_container_runtime.py::test_alpha_import_limit_defaults_are_runtime_defaults tests/integration/test_container_runtime.py::test_alpha_import_limit_env_overrides_are_applied tests/integration/test_container_runtime.py::test_alpha_import_limit_invalid_env_falls_back_to_defaults tests/integration/test_container_runtime.py::test_alpha_webauthn_env_is_parsed_by_upstream_initializer -m integration`
- `git diff --check`

## Notes
- publish only the `sure-alpha` component after merge
- stable `sure-aio` is unchanged by this release PR
