### PR TITLE
chore(release): 0.7.2-alpha.1-aio.1

### DIFF
--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -32,11 +32,12 @@ This template is meant for testing and local validation, not primary household f
 - [code]/mnt/user/appdata/sure-aio-alpha/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio-alpha/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio-alpha/redis[/code]</Overview>
-  <Changes>### 2026-06-01&#xD;
+  <Changes>### 2026-06-02&#xD;
 - Generated from CHANGELOG.alpha.md during release preparation. Do not edit manually.&#xD;
-- Preserve Rails origin checks behind reverse proxies.&#xD;
-- Add null-origin compatibility for Sure 0.7.1 alpha proxy login paths.&#xD;
-- Allow the browser service worker behind reverse proxies without triggering Rails cross-origin JavaScript protection.</Changes>
+- Track upstream Sure Alpha 0.7.2-alpha.1.&#xD;
+- Publish Docker Hub and GHCR tags with the configured component revision tag.&#xD;
+- Preserve the Sure AIO alpha import-limit, strict import preflight, and route-parity importer overlays.&#xD;
+- Keep alpha import and WebAuthn controls separate from stable.</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <Beta>True</Beta>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -364,7 +364,7 @@ def test_alpha_overlay_is_documented_and_copied() -> None:
 def test_alpha_dockerfile_declares_revision_and_repo_metadata() -> None:
     alpha = (ROOT / "Dockerfile.alpha").read_text()
 
-    assert "ARG AIO_REVISION=2" in alpha  # nosec B101
+    assert "ARG AIO_REVISION=1" in alpha  # nosec B101
     assert (  # nosec B101
         'org.opencontainers.image.source="https://github.com/JSONbored/sure-aio"'
         in alpha
@@ -398,9 +398,10 @@ def test_alpha_changelog_documents_runtime_differences() -> None:
     assert "SURE_IMPORT_MAX_ROWS" in overview  # nosec B101
     assert "strict SureImport preflight" in overview  # nosec B101
     assert "admin reset UI/task" in overview  # nosec B101
-    assert "Preserve Rails origin checks" in changes  # nosec B101
-    assert "null-origin compatibility" in changes  # nosec B101
-    assert "browser service worker" in changes  # nosec B101
+    assert "Track upstream Sure Alpha 0.7.2-alpha.1" in changes  # nosec B101
+    assert "configured component revision tag" in changes  # nosec B101
+    assert "import-limit" in changes  # nosec B101
+    assert "route-parity importer" in changes  # nosec B101
 
 
 def test_alpha_docs_use_dedicated_package_and_trimmed_tags() -> None:


### PR DESCRIPTION
## Summary
- prepare the Sure alpha `0.7.2-alpha.1-aio.1` release metadata

## What changed
- refreshed the alpha source Unraid XML `<Changes>` block
- updated alpha asset tests for the new upstream alpha revision

## Why
- the Sure alpha upstream bump has merged and the alpha template metadata needs to match before publishing `sure-alpha`

## Validation
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path <repo-path>`
- `python -m pytest tests/test_alpha_lane_assets.py -q`
- `git diff --check`

## Notes
- stable `sure-aio` runtime and template metadata are unchanged
- publish only the `sure-alpha` component after this merges and the central required check is green