### PR TITLE
chore(release): 0.7.2-alpha.2-aio.1

### DIFF
--- a/CHANGELOG.alpha.md
+++ b/CHANGELOG.alpha.md
@@ -6,6 +6,22 @@ are upstreamed or promoted to stable. Alpha uses the dedicated
 `jsonbored/sure-aio-alpha` image repo so testing tags stay out of the stable
 `jsonbored/sure-aio` package.
 
+## 0.7.2-alpha.2-aio.1 - 2026-06-02
+
+### Build
+
+- Track upstream Sure Alpha 0.7.2-alpha.2.
+- Publish Docker Hub and GHCR tags with the configured component revision tag.
+
+### Component Customizations
+
+- Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.
+- Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.
+- Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.
+- Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.
+- Do not add dirty-target taxonomy merge as a Unraid template or environment control.
+- Keep alpha passkey/WebAuthn template controls separate from stable.
+
 ## 0.7.2-alpha.1-aio.1 - 2026-06-02
 
 ### Build

--- a/Dockerfile.alpha
+++ b/Dockerfile.alpha
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 # checkov:skip=CKV_DOCKER_8: s6-overlay entrypoint must start as root so init scripts can prepare filesystem state before dropping privileges
 
-ARG UPSTREAM_VERSION=0.7.2-alpha.1
-ARG UPSTREAM_IMAGE_DIGEST=sha256:f5f55ece012f0389e7b66a3ec36caa28c04039722031c683828a0f8212cf1408
+ARG UPSTREAM_VERSION=0.7.2-alpha.2
+ARG UPSTREAM_IMAGE_DIGEST=sha256:b5d6d822fdef24c1af06ad455ce003139a2bd50cb6cf76a84a147dfd06b0e3dc
 ARG AIO_REVISION=1
 ARG PGVECTOR_VERSION=0.8.2
 FROM ghcr.io/we-promise/sure:${UPSTREAM_VERSION}@${UPSTREAM_IMAGE_DIGEST}

--- a/sure-aio-alpha.xml
+++ b/sure-aio-alpha.xml
@@ -34,10 +34,14 @@ This template is meant for testing and local validation, not primary household f
 - [code]/mnt/user/appdata/sure-aio-alpha/redis[/code]</Overview>
   <Changes>### 2026-06-02&#xD;
 - Generated from CHANGELOG.alpha.md during release preparation. Do not edit manually.&#xD;
-- Track upstream Sure Alpha 0.7.2-alpha.1.&#xD;
+- Track upstream Sure Alpha 0.7.2-alpha.2.&#xD;
 - Publish Docker Hub and GHCR tags with the configured component revision tag.&#xD;
-- Preserve the Sure AIO alpha import-limit, strict import preflight, and route-parity importer overlays.&#xD;
-- Keep alpha import and WebAuthn controls separate from stable.</Changes>
+- Preserve the Sure AIO alpha import-limit overlay documented in `docs/alpha-lane.md`.&#xD;
+- Preserve the strict SureImport preflight/failure overlay until the pinned upstream alpha includes equivalent behavior.&#xD;
+- Preserve the route-parity importer overlay for Enhanced NDJSON split/transfer proof packages until upstream carries it.&#xD;
+- Keep `SURE_IMPORT_MAX_NDJSON_SIZE_MB` and `SURE_IMPORT_MAX_ROWS` alpha-only.&#xD;
+- Do not add dirty-target taxonomy merge as a Unraid template or environment control.&#xD;
+- Keep alpha passkey/WebAuthn template controls separate from stable.</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <Beta>True</Beta>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>

--- a/tests/test_alpha_lane_assets.py
+++ b/tests/test_alpha_lane_assets.py
@@ -398,7 +398,7 @@ def test_alpha_changelog_documents_runtime_differences() -> None:
     assert "SURE_IMPORT_MAX_ROWS" in overview  # nosec B101
     assert "strict SureImport preflight" in overview  # nosec B101
     assert "admin reset UI/task" in overview  # nosec B101
-    assert "Track upstream Sure Alpha 0.7.2-alpha.1" in changes  # nosec B101
+    assert "Track upstream Sure Alpha 0.7.2-alpha.2" in changes  # nosec B101
     assert "configured component revision tag" in changes  # nosec B101
     assert "import-limit" in changes  # nosec B101
     assert "route-parity importer" in changes  # nosec B101


### PR DESCRIPTION
## Summary
- update the alpha lane to upstream Sure `0.7.2-alpha.2`
- publish the next alpha AIO revision metadata as `0.7.2-alpha.2-aio.1`

## What changed
- bumped `Dockerfile.alpha` to upstream `0.7.2-alpha.2` and its pinned GHCR digest
- added the `0.7.2-alpha.2-aio.1` alpha changelog entry
- refreshed `sure-aio-alpha.xml` release notes
- updated the alpha asset test expectation for the new upstream alpha version

## Why
- upstream published a newer Sure alpha prerelease, and the AIO alpha lane should track it separately from stable while preserving the existing alpha-only wrapper overlays

## Validation
- `python -m aio_fleet validate-repo --repo sure-aio --repo-path <repo>`
- `python -m aio_fleet cleanup-repo --repo sure-aio --repo-path <repo> --verify`
- `python -m pytest tests/test_alpha_lane_assets.py`
- `python -m pytest tests/integration/test_container_runtime.py::test_alpha_image_boots_with_version_import_limits_and_webauthn_env -m integration`
- `python -m pytest tests/integration/test_container_runtime.py::test_proxy_null_origin_escape_hatch_keeps_token_csrf_validation tests/integration/test_container_runtime.py::test_proxy_service_worker_does_not_trigger_cross_origin_js_guard -m integration`
- `git diff --check`

## Notes
- the proxy regressions were run against the locally built alpha image by retagging it into the stable pytest slot, so this directly checks the shared reverse-proxy fix on the alpha base
- publish should target only the `sure-alpha` component after the central required check passes