### PR TITLE
chore(release): 0.7.1-hotfix.1-aio.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.7.1-hotfix.1-aio.1 - 2026-06-12
+
+### Maintenance
+
+- Bump sure alpha to 0.7.2-alpha.1
+
+- Update upstream pins for sure-aio (#135)
+
 ## 0.7.1-aio.2 - 2026-06-01
 
 ### Fixes

--- a/sure-aio.xml
+++ b/sure-aio.xml
@@ -31,9 +31,10 @@
 - [code]/mnt/user/appdata/sure-aio/system[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/postgres[/code]&#xD;
 - [code]/mnt/user/appdata/sure-aio/redis[/code]</Overview>
-  <Changes>### 2026-06-01&#xD;
+  <Changes>### 2026-06-12&#xD;
 - Generated from CHANGELOG.md during release preparation. Do not edit manually.&#xD;
-- Allow service worker behind reverse proxies</Changes>
+- Bump sure alpha to 0.7.2-alpha.1&#xD;
+- Update upstream pins for sure-aio (#135)</Changes>
   <Category>Productivity Tools:Utilities</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/sure-aio.xml</TemplateURL>


### PR DESCRIPTION
Formal release of `sure-aio` **0.7.1-hotfix.1-aio.1**. Adds CHANGELOG + Community Apps `<Changes>`; version/release tags + GitHub Release + catalog sync follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)