### PR TITLE
chore(fleet): enable alpha published smoke target

### DIFF
--- a/.aio-fleet.yml
+++ b/.aio-fleet.yml
@@ -293,6 +293,8 @@ components:
       - Keep alpha passkey/WebAuthn template controls separate from stable.
     floating_tags:
       - latest-alpha
+    smoke_test:
+      enabled: true
     include_upstream_version_tag: false
     include_sha_tag: false
     preserve_tags:


### PR DESCRIPTION
## Summary
- syncs the Sure app fleet contract with the central smoke-test target configuration

## What changed
- enables the sure-alpha component as an explicit published-image smoke target in .aio-fleet.yml

## Why
- the central fleet smoke workflow now supports component image coverage, and the alpha package should be boot-smoked alongside stable

## Validation
- uv run aio-fleet validate --repo sure-aio
- uv run aio-fleet validate --all
- git diff --check
- focused published-image smoke for sure-aio:latest and sure-aio-alpha:latest-alpha on linux/amd64